### PR TITLE
Updating hieradata hostnames/ips to work in default profile and worker manager profiles

### DIFF
--- a/hieradata/dev/wso2/wso2am/1.9.1/default.yaml
+++ b/hieradata/dev/wso2/wso2am/1.9.1/default.yaml
@@ -21,7 +21,7 @@ wso2::template_list :
   - repository/conf/datasources/am-datasources.xml
 
 wso2::service_name: wso2am
-wso2::hostname : am.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::ports:
 #  proxyPort :

--- a/hieradata/dev/wso2/wso2as/5.3.0/default.yaml
+++ b/hieradata/dev/wso2/wso2as/5.3.0/default.yaml
@@ -19,7 +19,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2as
-wso2::hostname : as.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.36.jar

--- a/hieradata/dev/wso2/wso2as/5.3.0/manager.yaml
+++ b/hieradata/dev/wso2/wso2as/5.3.0/manager.yaml
@@ -17,7 +17,7 @@ wso2::mgt_hostname : mgt.as.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.13
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : mgt

--- a/hieradata/dev/wso2/wso2as/5.3.0/worker.yaml
+++ b/hieradata/dev/wso2/wso2as/5.3.0/worker.yaml
@@ -15,7 +15,7 @@
 ---
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.23
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : worker

--- a/hieradata/dev/wso2/wso2bps/3.5.0/default.yaml
+++ b/hieradata/dev/wso2/wso2bps/3.5.0/default.yaml
@@ -26,7 +26,7 @@ wso2::template_list :
         - repository/conf/jndi.properties
 
 wso2::service_name: wso2bps
-wso2::hostname : bps.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.36.jar

--- a/hieradata/dev/wso2/wso2bps/3.5.0/manager.yaml
+++ b/hieradata/dev/wso2/wso2bps/3.5.0/manager.yaml
@@ -17,7 +17,7 @@ wso2::mgt_hostname : mgt.bps.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.10
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : mgt

--- a/hieradata/dev/wso2/wso2bps/3.5.0/worker.yaml
+++ b/hieradata/dev/wso2/wso2bps/3.5.0/worker.yaml
@@ -15,7 +15,7 @@
 ---
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.20
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : worker

--- a/hieradata/dev/wso2/wso2brs/2.1.0/default.yaml
+++ b/hieradata/dev/wso2/wso2brs/2.1.0/default.yaml
@@ -19,7 +19,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2brs
-wso2::hostname : brs.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.36-bin.jar

--- a/hieradata/dev/wso2/wso2brs/2.1.0/manager.yaml
+++ b/hieradata/dev/wso2/wso2brs/2.1.0/manager.yaml
@@ -17,7 +17,7 @@ wso2::mgt_hostname : mgt.brs.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.10
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : mgt

--- a/hieradata/dev/wso2/wso2brs/2.1.0/worker.yaml
+++ b/hieradata/dev/wso2/wso2brs/2.1.0/worker.yaml
@@ -15,7 +15,7 @@
 ---
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.20
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : worker

--- a/hieradata/dev/wso2/wso2brs/2.2.0/default.yaml
+++ b/hieradata/dev/wso2/wso2brs/2.2.0/default.yaml
@@ -19,7 +19,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2brs
-wso2::hostname : brs.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.36-bin.jar

--- a/hieradata/dev/wso2/wso2brs/2.2.0/manager.yaml
+++ b/hieradata/dev/wso2/wso2brs/2.2.0/manager.yaml
@@ -17,7 +17,7 @@ wso2::mgt_hostname : mgt.brs.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.10
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : mgt

--- a/hieradata/dev/wso2/wso2brs/2.2.0/worker.yaml
+++ b/hieradata/dev/wso2/wso2brs/2.2.0/worker.yaml
@@ -15,7 +15,7 @@
 ---
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.20
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : worker

--- a/hieradata/dev/wso2/wso2cep/4.0.0/default.yaml
+++ b/hieradata/dev/wso2/wso2cep/4.0.0/default.yaml
@@ -25,7 +25,7 @@ wso2::template_list :
         - repository/conf/data-bridge/data-bridge-config.xml
 
 wso2::service_name: wso2cep
-wso2::hostname : cep.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.34-bin.jar

--- a/hieradata/dev/wso2/wso2das/3.0.0/default.yaml
+++ b/hieradata/dev/wso2/wso2das/3.0.0/default.yaml
@@ -23,7 +23,7 @@ wso2::template_list :
         - repository/conf/analytics/spark/spark-defaults.conf
 
 wso2::service_name: wso2das
-wso2::hostname : das.wso2.com
+wso2::hostname : "%{::hostname}"
 
 wso2::spark_master_count : 1
 

--- a/hieradata/dev/wso2/wso2dss/3.5.0/default.yaml
+++ b/hieradata/dev/wso2/wso2dss/3.5.0/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2dss
-wso2::hostname : dss.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.36.jar

--- a/hieradata/dev/wso2/wso2es/2.0.0/default.yaml
+++ b/hieradata/dev/wso2/wso2es/2.0.0/default.yaml
@@ -21,7 +21,7 @@ wso2::template_list :
         - repository/conf/datasources/social-datasources.xml
 
 wso2::service_name: wso2es
-wso2::hostname : es.wso2.com
+wso2::hostname : "%{::hostname}"
 wso2::mgt_hostname : es.wso2.com
 
 wso2::file_list :

--- a/hieradata/dev/wso2/wso2es/2.0.0/manager.yaml
+++ b/hieradata/dev/wso2/wso2es/2.0.0/manager.yaml
@@ -17,7 +17,7 @@ wso2::hostname : es.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : local.es.wso2.com
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : kubernetes
     k8 :

--- a/hieradata/dev/wso2/wso2es/2.0.0/worker.yaml
+++ b/hieradata/dev/wso2/wso2es/2.0.0/worker.yaml
@@ -16,7 +16,7 @@ wso2::hostname : es.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : local.es.wso2.com
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : kubernetes
     k8 :

--- a/hieradata/dev/wso2/wso2esb/4.9.0/default.yaml
+++ b/hieradata/dev/wso2/wso2esb/4.9.0/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2esb
-wso2::hostname : esb.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.38.jar

--- a/hieradata/dev/wso2/wso2esb/4.9.0/manager.yaml
+++ b/hieradata/dev/wso2/wso2esb/4.9.0/manager.yaml
@@ -16,7 +16,7 @@ wso2::mgt_hostname : mgt.esb.wso2.com
 
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.10
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : mgt

--- a/hieradata/dev/wso2/wso2esb/4.9.0/worker.yaml
+++ b/hieradata/dev/wso2/wso2esb/4.9.0/worker.yaml
@@ -14,7 +14,7 @@
 ---
 wso2::clustering :
     enabled : true
-    local_member_host : 192.168.100.20
+    local_member_host : "%{::ipaddress}"
     local_member_port : 4000
     membership_scheme : wka
     sub_domain : worker

--- a/hieradata/dev/wso2/wso2greg/4.6.0/default.yaml
+++ b/hieradata/dev/wso2/wso2greg/4.6.0/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2greg
-wso2::hostname : greg.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.38.jar

--- a/hieradata/dev/wso2/wso2greg/5.1.0/default.yaml
+++ b/hieradata/dev/wso2/wso2greg/5.1.0/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2greg
-wso2::hostname : greg.wso2.com
+wso2::hostname : "%{::hostname}"
 
 #wso2::file_list :
 #  - repository/components/lib/mysql-connector-java-5.1.38.jar

--- a/hieradata/dev/wso2/wso2is/5.0.0/default.yaml
+++ b/hieradata/dev/wso2/wso2is/5.0.0/default.yaml
@@ -20,7 +20,7 @@ wso2::template_list :
   - repository/conf/datasources/am-datasources.xml
 
 wso2::service_name: wso2is
-wso2::hostname : is.wso2.com
+wso2::hostname : "%{::hostname}"
 
 wso2::clustering :
     enabled : false

--- a/hieradata/dev/wso2/wso2is/5.1.0/default.yaml
+++ b/hieradata/dev/wso2/wso2is/5.1.0/default.yaml
@@ -22,7 +22,7 @@ wso2::template_list :
   - repository/conf/datasources/metrics-datasources.xml
 
 wso2::service_name: wso2is
-wso2::hostname : is.wso2.com
+wso2::hostname : "%{::hostname}"
 
 wso2::clustering :
     enabled : false

--- a/hieradata/dev/wso2/wso2mb/3.0.0/default.yaml
+++ b/hieradata/dev/wso2/wso2mb/3.0.0/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2mb
-wso2::hostname : mb.wso2.com
+wso2::hostname : "%{::hostname}"
 
 wso2::template_list :
   - repository/conf/broker.xml

--- a/hieradata/dev/wso2/wso2ppaas/4.1.0/default.yaml
+++ b/hieradata/dev/wso2/wso2ppaas/4.1.0/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2ppaas
-wso2::hostname : ppaas.wso2.com
+wso2::hostname : "%{::hostname}"
 
 wso2::template_list :
         - repository/conf/jndi.properties

--- a/hieradata/dev/wso2/wso2ppaas/4.1.1/default.yaml
+++ b/hieradata/dev/wso2/wso2ppaas/4.1.1/default.yaml
@@ -18,7 +18,7 @@ wso2::pack_filename: "%{::product_name}-%{::product_version}.zip"
 wso2::pack_extracted_dir: "%{::product_name}-%{::product_version}"
 
 wso2::service_name: wso2ppaas
-wso2::hostname : ppaas.wso2.com
+wso2::hostname : "%{::hostname}"
 
 wso2::template_list :
         - repository/conf/jndi.properties


### PR DESCRIPTION
Although this is an optional change to the data layer(hiera), this will be helpful in VM scenario to,
- Avoid UnknownHostException if default profile is used without altering hiera default.yaml
- Have multiple workers, local_member_host should be a variable.
