### PR TITLE
Adding secure vault support for modules

### DIFF
--- a/hieradata/dev/wso2/common.yaml
+++ b/hieradata/dev/wso2/common.yaml
@@ -45,6 +45,10 @@ wso2::template_list :
   - repository/conf/tomcat/catalina-server.xml
   - repository/conf/axis2/axis2.xml
   - bin/wso2server.sh
+#   - repository/conf/security/cipher-text.properties
+#   - repository/conf/security/cipher-tool.properties
+#   - bin/ciphertool.sh
+#   - password-tmp
 
 # File list to be copied to the server
 wso2::file_list : []
@@ -149,3 +153,32 @@ wso2::datasources::h2::validation_query : 'SELECT 1'
 
 # MySQL datasources configuration
 wso2::datasources::mysql::validation_query : 'SELECT 1'
+
+# Secure vault configuration
+wso2::enable_secure_vault : false
+wso2::secure_vault_configs :
+  key_store_password :
+    secret_alias: Carbon.Security.KeyStore.Password
+    secret_alias_value: repository/conf/carbon.xml//Server/Security/KeyStore/Password,false
+    password: wso2carbon
+  key_store_key_password :
+    secret_alias: Carbon.Security.KeyStore.KeyPassword
+    secret_alias_value: repository/conf/carbon.xml//Server/Security/KeyStore/KeyPassword,false
+    password: wso2carbon
+  trust_store_password :
+    secret_alias: Carbon.Security.TrustStore.Password
+    secret_alias_value: repository/conf/carbon.xml//Server/Security/TrustStore/Password,false
+    password: wso2carbon
+  user_manager_admin_password :
+    secret_alias: UserManager.AdminUser.Password
+    secret_alias_value: repository/conf/user-mgt.xml//UserManager/Realm/Configuration/AdminUser/Password,false
+    password: admin
+  wso2_carbon_db_password :
+    secret_alias: Datasources.WSO2_CARBON_DB.Configuration.Password
+    secret_alias_value: repository/conf/datasources/master-datasources.xml//datasources-configuration/datasources/datasource[name='WSO2_CARBON_DB']/definition[@type='RDBMS']/configuration/password,false
+    password: wso2carbon
+  connector_key_store_password :
+    secret_alias: Server.Service.Connector.keystorePass
+    secret_alias_value: repository/conf/tomcat/catalina-server.xml//Server/Service/Connector[@keystorePass],true
+    password: wso2carbon
+

--- a/modules/wso2am/manifests/init.pp
+++ b/modules/wso2am/manifests/init.pp
@@ -26,19 +26,21 @@ class wso2am inherits wso2base {
   $apim_store         = hiera_hash ("wso2::apim_store")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2am/templates/1.10.0/bin/ciphertool.sh.erb
+++ b/modules/wso2am/templates/1.10.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2am/templates/1.10.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2am/templates/1.10.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2am/templates/1.10.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2am/templates/1.10.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2am/templates/1.9.1/bin/ciphertool.sh.erb
+++ b/modules/wso2am/templates/1.9.1/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2am/templates/1.9.1/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2am/templates/1.9.1/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2am/templates/1.9.1/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2am/templates/1.9.1/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2as/manifests/init.pp
+++ b/modules/wso2as/manifests/init.pp
@@ -19,19 +19,21 @@
 
 class wso2as inherits wso2base {
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2as/templates/5.3.0/bin/ciphertool.sh.erb
+++ b/modules/wso2as/templates/5.3.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2as/templates/5.3.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2as/templates/5.3.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2as/templates/5.3.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2as/templates/5.3.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2base/manifests/apply_secure_vault.pp
+++ b/modules/wso2base/manifests/apply_secure_vault.pp
@@ -1,0 +1,29 @@
+#  Copyright (c) 2015 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+define wso2base::apply_secure_vault ($user, $enable_secure_vault, $key_store_password) {
+  $carbon_home  = $name
+
+  if $enable_secure_vault {
+    notice("Applying secure vault for WSO2 product [name] ${::product_name}, [version] ${::product_version},
+    [CARBON_HOME] ${carbon_home}")
+    exec { "Applying secure vault":
+      user               => $user,
+      path               => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      command            => "$carbon_home/bin/ciphertool.sh -Dconfigure -Dpassword=$key_store_password",
+      logoutput          => 'on_failure'
+    }
+  }
+}

--- a/modules/wso2base/manifests/init.pp
+++ b/modules/wso2base/manifests/init.pp
@@ -55,6 +55,11 @@ class wso2base {
   $ipaddress          = hiera("wso2::ipaddress")
   $fqdn               = hiera("wso2::fqdn")
 
+  #secure_vault configurations
+  $enable_secure_vault = hiera("wso2::enable_secure_vault")
+  $secure_vault_configs = hiera_hash("wso2::secure_vault_configs")
+  $key_store_password = $secure_vault_configs['key_store_password']['password']
+
   $carbon_home        = "${install_dir}/${pack_extracted_dir}"
 
   class { '::wso2base::system':

--- a/modules/wso2bps/manifests/init.pp
+++ b/modules/wso2bps/manifests/init.pp
@@ -33,19 +33,21 @@ class wso2bps inherits wso2base {
   $bps_datasources                            = hiera("wso2::bps_datasources")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2bps/templates/3.5.0/bin/ciphertool.sh.erb
+++ b/modules/wso2bps/templates/3.5.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2bps/templates/3.5.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2bps/templates/3.5.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2bps/templates/3.5.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2bps/templates/3.5.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2brs/manifests/init.pp
+++ b/modules/wso2brs/manifests/init.pp
@@ -21,19 +21,21 @@
 class wso2brs inherits wso2base {
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2brs/templates/2.1.0/bin/ciphertool.sh.erb
+++ b/modules/wso2brs/templates/2.1.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2brs/templates/2.1.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2brs/templates/2.1.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2brs/templates/2.1.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2brs/templates/2.1.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2brs/templates/2.2.0/bin/ciphertool.sh.erb
+++ b/modules/wso2brs/templates/2.2.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2brs/templates/2.2.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2brs/templates/2.2.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2brs/templates/2.2.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2brs/templates/2.2.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2cep/manifests/init.pp
+++ b/modules/wso2cep/manifests/init.pp
@@ -19,29 +19,31 @@
 
 class wso2cep inherits wso2base {
 
-  $jvm                                        = hiera("wso2::jvm") 
+  $jvm                                        = hiera("wso2::jvm")
   $thrift_data_agent                          = hiera("wso2::thrift_data_agent")
   $binary_data_agent                          = hiera("wso2::binary_data_agent")
   $data_bridge                                = hiera("wso2::data_bridge")
   $single_node_deployment                     = hiera("wso2::single_node_deployment")
   $ha_deployment                              = hiera("wso2::ha_deployment")
   $distributed_deployment                     = hiera("wso2::distributed_deployment")
-  
+
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2cep/templates/4.0.0/bin/ciphertool.sh.erb
+++ b/modules/wso2cep/templates/4.0.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2cep/templates/4.0.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2cep/templates/4.0.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2cep/templates/4.0.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2cep/templates/4.0.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2das/manifests/init.pp
+++ b/modules/wso2das/manifests/init.pp
@@ -24,20 +24,22 @@ class wso2das inherits wso2base {
   $spark_master_count      = hiera("wso2::spark_master_count")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 
 }

--- a/modules/wso2das/templates/3.0.0/bin/ciphertool.sh.erb
+++ b/modules/wso2das/templates/3.0.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2das/templates/3.0.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2das/templates/3.0.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2das/templates/3.0.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2das/templates/3.0.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2dss/manifests/init.pp
+++ b/modules/wso2dss/manifests/init.pp
@@ -22,19 +22,21 @@ class wso2dss inherits wso2base {
   $taskServerCount                      = hiera("wso2::taskServerCount")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2dss/templates/3.5.0/bin/ciphertool.sh.erb
+++ b/modules/wso2dss/templates/3.5.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2dss/templates/3.5.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2dss/templates/3.5.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2dss/templates/3.5.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2dss/templates/3.5.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2es/manifests/init.pp
+++ b/modules/wso2es/manifests/init.pp
@@ -21,19 +21,21 @@ class wso2es inherits wso2base {
   $social_datasources     = hiera_hash("wso2::social_datasources")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2es/templates/2.0.0/bin/ciphertool.sh.erb
+++ b/modules/wso2es/templates/2.0.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2es/templates/2.0.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2es/templates/2.0.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2es/templates/2.0.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2es/templates/2.0.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2esb/manifests/init.pp
+++ b/modules/wso2esb/manifests/init.pp
@@ -19,19 +19,21 @@
 
 class wso2esb inherits wso2base {
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2esb/templates/4.9.0/bin/ciphertool.sh.erb
+++ b/modules/wso2esb/templates/4.9.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2esb/templates/4.9.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2esb/templates/4.9.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2esb/templates/4.9.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2esb/templates/4.9.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2greg/manifests/init.pp
+++ b/modules/wso2greg/manifests/init.pp
@@ -23,19 +23,21 @@ class wso2greg inherits wso2base {
   $social_datasources = hiera_hash("wso2::social_datasources")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2greg/templates/4.6.0/bin/ciphertool.sh.erb
+++ b/modules/wso2greg/templates/4.6.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2greg/templates/4.6.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2greg/templates/4.6.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2greg/templates/4.6.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2greg/templates/4.6.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2greg/templates/5.1.0/bin/ciphertool.sh.erb
+++ b/modules/wso2greg/templates/5.1.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2greg/templates/5.1.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2greg/templates/5.1.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2greg/templates/5.1.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2greg/templates/5.1.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2is/manifests/init.pp
+++ b/modules/wso2is/manifests/init.pp
@@ -25,19 +25,21 @@ class wso2is inherits wso2base {
   $metrics_datasources = hiera_hash("wso2::metrics_datasources")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2is/templates/5.0.0/bin/ciphertool.sh.erb
+++ b/modules/wso2is/templates/5.0.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2is/templates/5.0.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2is/templates/5.0.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2is/templates/5.0.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2is/templates/5.0.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2is/templates/5.1.0/bin/ciphertool.sh.erb
+++ b/modules/wso2is/templates/5.1.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2is/templates/5.1.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2is/templates/5.1.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2is/templates/5.1.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2is/templates/5.1.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2mb/manifests/init.pp
+++ b/modules/wso2mb/manifests/init.pp
@@ -23,19 +23,21 @@ class wso2mb inherits wso2base {
   $metrics_datasources      = hiera("wso2::metrics_datasources")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2mb/templates/3.0.0/bin/ciphertool.sh.erb
+++ b/modules/wso2mb/templates/3.0.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2mb/templates/3.0.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2mb/templates/3.0.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2mb/templates/3.0.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2mb/templates/3.0.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2ppaas/manifests/init.pp
+++ b/modules/wso2ppaas/manifests/init.pp
@@ -31,19 +31,21 @@ class wso2ppaas inherits wso2base {
   $iaas_providers = hiera_hash("wso2::ppaas::iaas_providers")
 
   wso2base::server { "${carbon_home}" :
-    maintenance_mode   => $maintenance_mode,
-    pack_filename      => $pack_filename,
-    pack_dir           => $pack_dir,
-    install_mode       => $install_mode,
-    install_dir        => $install_dir,
-    pack_extracted_dir => $pack_extracted_dir,
-    wso2_user          => $wso2_user,
-    wso2_group         => $wso2_group,
-    patches_dir        => $patches_dir,
-    service_name       => $service_name,
-    service_template   => $service_template,
-    hosts_template     => $hosts_template,
-    template_list      => $template_list,
-    file_list          => $file_list
+    maintenance_mode    => $maintenance_mode,
+    pack_filename       => $pack_filename,
+    pack_dir            => $pack_dir,
+    install_mode        => $install_mode,
+    install_dir         => $install_dir,
+    pack_extracted_dir  => $pack_extracted_dir,
+    wso2_user           => $wso2_user,
+    wso2_group          => $wso2_group,
+    patches_dir         => $patches_dir,
+    service_name        => $service_name,
+    service_template    => $service_template,
+    hosts_template      => $hosts_template,
+    template_list       => $template_list,
+    file_list           => $file_list,
+    enable_secure_vault => $enable_secure_vault,
+    key_store_password  => $key_store_password
   }
 }

--- a/modules/wso2ppaas/templates/4.1.0/bin/ciphertool.sh.erb
+++ b/modules/wso2ppaas/templates/4.1.0/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2ppaas/templates/4.1.0/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2ppaas/templates/4.1.0/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2ppaas/templates/4.1.0/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2ppaas/templates/4.1.0/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>

--- a/modules/wso2ppaas/templates/4.1.1/bin/ciphertool.sh.erb
+++ b/modules/wso2ppaas/templates/4.1.1/bin/ciphertool.sh.erb
@@ -1,0 +1,134 @@
+#!/bin/sh
+# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# -----------------------------------------------------------------------------
+# ciphertool script for generating stub, skeleton and other required classes
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of CARBON installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+
+# if JAVA_HOME is not set we're not happy
+
+JAVA_HOME=<%= @java_home %>
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+           JAVA_VERSION="CurrentJDK"
+        else
+           echo "Using Java version: $JAVA_VERSION"
+        fi
+        if [ -z "$JAVA_HOME" ] ; then
+           JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+        fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+# update classpath
+CARBON_CLASSPATH=""
+for f in "$CARBON_HOME"/lib/org.wso2.ciphertool*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
+done
+for h in "$CARBON_HOME"/repository/components/plugins/*.jar
+do
+  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
+done
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*

--- a/modules/wso2ppaas/templates/4.1.1/repository/conf/security/cipher-text.properties.erb
+++ b/modules/wso2ppaas/templates/4.1.1/repository/conf/security/cipher-text.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=[<%= secure_vault_config['password'] %>]
+<%- end -%>

--- a/modules/wso2ppaas/templates/4.1.1/repository/conf/security/cipher-tool.properties.erb
+++ b/modules/wso2ppaas/templates/4.1.1/repository/conf/security/cipher-tool.properties.erb
@@ -1,0 +1,27 @@
+#
+#   Copyright (c) 2015 WSO2, Inc. (http://wso2.com)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Important: This properties file contains all the aliases to be used in carbon components. If any property need to
+#be secured, you need to add alias name, file name and the xpath as follows:.
+# The value goes as, the <file_name>//<xpath>,<true/false>
+# where <file_name> - is the file (along with the file path) to be secured,
+#       <xpath> - is the xpath to the property value to be secured
+#       <true / false> - This is true if the last parameter in the xpath is parameter (starts with [ and ends with ])
+# and you want its value to be replaced with "password"
+ 
+<%- @secure_vault_configs.each do |secure_vault_config_name, secure_vault_config| -%>
+  <%= secure_vault_config['secret_alias'] %>=<%= secure_vault_config['secret_alias_value'] %>
+<%- end -%>


### PR DESCRIPTION
This p/r is to add secure vault support for puppet modules.

By default **secure vault is disabled** for all modules in wso2 common.yaml (**wso2::enable_secure_vault : false**).

You can enable secure vault for a product using following steps:
1.  Enable secure vault in product default.yaml file as
     **wso2::enable_secure_vault : true**
1.  Add needed secret vault configs in **wso2::secure_vault_configs** with following format in defult yaml file
   `<secure_vault_config_name>`:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;secret_alias: `<secret alias used for secure vault config>`
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;secret_alias_value: `<secret alias value as in <file_name>//<xpath>,<true/false> format>`
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password: `<password>`
2. Add the following templates needed for secret vault config to **wso2::template_list**
       - repository/conf/security/cipher-text.properties
       - repository/conf/security/cipher-tool.properties
       - bin/ciphertool.sh
       - password-tmp`

**password-tmp needs to be added to templates with key_store_password variable** (<%= @key_store_password %>)

**Note: I have added secret vault configs common to all products as below**
key_store_password
key_store_key_password
trust_store_password
user_manager_admin_password:
wso2_carbon_db_password
connector_key_store_password 
