### PR TITLE
Changing wso2_user_db master datasource name

### DIFF
--- a/hieradata/dev/wso2/common.yaml
+++ b/hieradata/dev/wso2/common.yaml
@@ -45,10 +45,10 @@ wso2::template_list :
   - repository/conf/tomcat/catalina-server.xml
   - repository/conf/axis2/axis2.xml
   - bin/wso2server.sh
-#   - repository/conf/security/cipher-text.properties
-#   - repository/conf/security/cipher-tool.properties
-#   - bin/ciphertool.sh
-#   - password-tmp
+#  - repository/conf/security/cipher-text.properties
+#  - repository/conf/security/cipher-tool.properties
+#  - bin/ciphertool.sh
+#  - password-tmp
 
 # File list to be copied to the server
 wso2::file_list : []
@@ -121,14 +121,14 @@ wso2::master_datasources :
     validation_query : "%{hiera('wso2::datasources::h2::validation_query')}"
     validation_interval : "%{hiera('wso2::datasources::common::validation_interval')}"
   wso2user_db :
-    name : WSO2_CARBON_DB
+    name : WSO2_USER_DB
     description : The datasource is used for user mangement and userstore
     driver_class_name : org.h2.Driver
     url : jdbc:h2:repository/database/WSO2CARBON_DB?autoReconnect=true
     username : "%{hiera('wso2::datasources::common::username')}"
     password : "%{hiera('wso2::datasources::common::password')}"
     #secretAlias :
-    jndi_config : jdbc/WSO2_CARBON_DB
+    jndi_config : jdbc/WSO2_USER_DB
     max_active : "%{hiera('wso2::datasources::common::max_active')}"
     max_wait : "%{hiera('wso2::datasources::common::max_wait')}"
     test_on_borrow : "%{hiera('wso2::datasources::common::test_on_borrow')}"


### PR DESCRIPTION
This p/r is to change the user_db datasource name. Currently both carbon db and user db are using the same name.
