### PR TITLE
Updating server startup script with workerNode param by checking the profile

### DIFF
--- a/modules/wso2am/templates/1.10.0/bin/wso2server.sh.erb
+++ b/modules/wso2am/templates/1.10.0/bin/wso2server.sh.erb
@@ -317,9 +317,11 @@ do
     -Dfile.encoding=UTF8 \
     -Djava.net.preferIPv4Stack=true \
     -Dcom.ibm.cacheLocalHost=true \
-    <%- if @worker_node -%>
+<%- if @product_profile == 'gateway-worker' -%>
     -DworkerNode=true \
-    <%- end -%>
+<%- else -%>
+    -DworkerNode=false \
+<%- end -%>
     -Dprofile=<%= @product_profile %> \
     org.wso2.carbon.bootstrap.Bootstrap $*
     status=$?


### PR DESCRIPTION
This p/r is to fix the issue of user is able login via gateway worker mgmt console in APIM 1.10 by adding '-DworkerNode=true' to wso2server.sh script.
