### PR TITLE
Adding mysql metrics datasource to MB

### DIFF
--- a/hieradata/dev/wso2/wso2mb/3.0.0/default/default.yaml
+++ b/hieradata/dev/wso2/wso2mb/3.0.0/default/default.yaml
@@ -39,8 +39,8 @@ wso2::master_datasources:
   wso2_mb_store_db:
     name: WSO2_MB_STORE_DB
     description: The datasource used for message broker database
-    driver_class_name: org.h2.Driver
-    url: jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000
+    driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
+    url: jdbc:h2:repository/database/WSO2MB_STORE_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000
     username: "%{hiera('wso2::datasources::common::username')}"
     password: "%{hiera('wso2::datasources::common::password')}"
     jndi_config: WSO2MBStoreDB
@@ -113,10 +113,11 @@ wso2::master_datasources:
 #    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
 wso2::metrics_datasources:
+# Comment the following h2 data source for a clustered setup
   wso2_metrics_db:
     name: WSO2_METRICS_DB
     description: The default datasource used for WSO2 Carbon Metrics
-    driver_class_name: org.h2.Driver
+    driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
     url: jdbc:h2:repository/database/WSO2METRICS_DB;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
     username: "%{hiera('wso2::datasources::common::username')}"
     password: "%{hiera('wso2::datasources::common::password')}"
@@ -128,6 +129,23 @@ wso2::metrics_datasources:
     default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
     validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
     validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+
+# Uncomment the following MySQL data source for a clustered setup
+#  wso2_metrics_db:
+#    name: WSO2_METRICS_DB
+#    description: The default datasource used for WSO2 Carbon Metrics
+#    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+#    url: jdbc:mysql://192.168.100.1:3306/WSO2_MB_DB?autoReconnect=true
+#    username: "%{hiera('wso2::datasources::mysql::username')}"
+#    password: "%{hiera('wso2::datasources::mysql::password')}"
+#    jndi_config: jdbc/WSO2MetricsDB
+#    datasource: WSO2MetricsDB
+#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+#    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
 # Uncomment MySQL connector driver for a clustered setup
 #wso2::file_list:

--- a/hieradata/dev/wso2/wso2mb/3.1.0/default/default.yaml
+++ b/hieradata/dev/wso2/wso2mb/3.1.0/default/default.yaml
@@ -34,23 +34,23 @@ wso2::mb_thrift_port: 7611
 # Uncomment the following for a clustered setup
 #wso2::usermgt_datasource: wso2user_db
 
-# Comment this datasource for the Clustered setup.
 wso2::master_datasources:
 # Comment the following h2 data source for a clustered setup
-#  wso2_mb_store_db:
-#    name: WSO2_MB_STORE_DB
-#    description: The datasource used for message broker database
-#    driver_class_name: org.h2.Driver
-#    url: jdbc:h2:repository/database/WSO2MB_STORE_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000
-#    username: "%{hiera('wso2::datasources::common::username')}"
-#    password: "%{hiera('wso2::datasources::common::password')}"
-#    jndi_config: WSO2MBStoreDB
-#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
-#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
-#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
-#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-#    validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
-#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+  wso2_mb_store_db:
+    name: WSO2_MB_STORE_DB
+    description: The datasource used for message broker database
+    driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
+    url: jdbc:h2:repository/database/WSO2MB_STORE_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000
+    username: "%{hiera('wso2::datasources::common::username')}"
+    password: "%{hiera('wso2::datasources::common::password')}"
+    jndi_config: WSO2MBStoreDB
+    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+    validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
+    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+
 # Uncomment the following MySQL data sources for a clustered setup
 #  wso2_config_db:
 #    name: WSO2_CONFIG_DB
@@ -113,10 +113,11 @@ wso2::master_datasources:
 #    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
 wso2::metrics_datasources:
+# Comment the following h2 data source for a clustered setup
   wso2_metrics_db:
     name: WSO2_METRICS_DB
     description: The default datasource used for WSO2 Carbon Metrics
-    driver_class_name: org.h2.Driver
+    driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
     url: jdbc:h2:repository/database/WSO2METRICS_DB;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
     username: "%{hiera('wso2::datasources::common::username')}"
     password: "%{hiera('wso2::datasources::common::password')}"
@@ -128,6 +129,23 @@ wso2::metrics_datasources:
     default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
     validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
     validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+
+# Uncomment the following MySQL data source for a clustered setup
+#  wso2_metrics_db:
+#    name: WSO2_METRICS_DB
+#    description: The default datasource used for WSO2 Carbon Metrics
+#    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+#    url: jdbc:mysql://192.168.100.1:3306/WSO2_MB_DB?autoReconnect=true
+#    username: "%{hiera('wso2::datasources::mysql::username')}"
+#    password: "%{hiera('wso2::datasources::mysql::password')}"
+#    jndi_config: jdbc/WSO2MetricsDB
+#    datasource: WSO2MetricsDB
+#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+#    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
 # Uncomment MySQL connector driver for a clustered setup
 #wso2::file_list:


### PR DESCRIPTION
This p/r includes following changes to MB hiera yaml files:
1. Adding mysql metrics datasource configuration
2. Updating driver class name with hiera lookup
3. Uncommenting h2 wso2_mb_store_db config in MB 3.1.0 default.yaml file
