### PR TITLE
move clustering hieradata to default.yaml

### DIFF
--- a/hieradata/dev/wso2/wso2am/1.10.0/mesos/default.yaml
+++ b/hieradata/dev/wso2/wso2am/1.10.0/mesos/default.yaml
@@ -34,7 +34,8 @@ wso2::mgt_hostname: marathon-lb.marathon.mesos
 wso2::clustering:
   enabled: true
   membership_scheme: mesos
-#  mesos:
+  mesos:
+    marathon_applications: wso2am-gateway-manager,wso2am-gateway-worker
 #    enable_marathon_basic_auth: true
 #    marathon_username: username
 #    marathon_username: password

--- a/hieradata/dev/wso2/wso2am/1.10.0/mesos/gateway-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/1.10.0/mesos/gateway-manager.yaml
@@ -41,16 +41,6 @@ wso2::apim_gateway:
   username: "%{hiera('wso2::super_admin::username')}"
   password: "%{hiera('wso2::super_admin::username')}"
 
-# Clustering
-wso2::clustering:
-  enabled: true
-  membership_scheme: mesos
-  mesos:
-    marathon_applications: wso2am-gateway-manager,wso2am-gateway-worker
-#    enable_marathon_basic_auth: true
-#    marathon_username: username
-#    marathon_username: password
-
 wso2::dep_sync:
   enabled: false
   auto_checkout: true

--- a/hieradata/dev/wso2/wso2am/1.10.0/mesos/gateway-worker.yaml
+++ b/hieradata/dev/wso2/wso2am/1.10.0/mesos/gateway-worker.yaml
@@ -36,16 +36,6 @@ wso2::apim_gateway:
   username: "%{hiera('wso2::super_admin::username')}"
   password: "%{hiera('wso2::super_admin::username')}"
 
-# Clustering
-wso2::clustering:
-  enabled: true
-  membership_scheme: mesos
-  mesos:
-    marathon_applications: wso2am-gateway-manager,wso2am-gateway-worker
-#    enable_marathon_basic_auth: true
-#    marathon_username: username
-#    marathon_username: password
-
 wso2::dep_sync:
   enabled: false
   auto_checkout: true


### PR DESCRIPTION
PR for https://github.com/wso2/puppet-modules/issues/76.
There are other places where we can move clustering to default.yaml . Will fix them later
