### PR TITLE
Include puppet scripts for APIM 2.0.0 fully distributed setup. (5 profiles, 5 nodes)

### DIFF
--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-key-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-key-manager.yaml
@@ -25,6 +25,10 @@ wso2::apim_traffic_manager:
   username: "%{hiera('wso2::super_admin::username')}"
   password: "%{hiera('wso2::super_admin::password')}"
 
+wso2::template_list:
+  - repository/conf/axis2/axis2_TM.xml
+  - repository/conf/registry_TM.xml
+
 wso2::clustering:
   enabled: true
   domain: km.am.wso2.domain
@@ -79,11 +83,11 @@ wso2::enable_thrift_server: false
 
 wso2::key_validator_client_type: WSClient
 
-# Uncomment the following in a distributed setup ( including the trust store with the certificate of the key manager and keystore)
 wso2::file_list:
   - "repository/resources/security/%{hiera('wso2::key_store')}"
   - "repository/resources/security/%{hiera('wso2::trust_store')}"
 wso2::enable_advance_throttling: true
 wso2::enable_data_publisher: false
 wso2::enable_jms_connection_details: false
-
+wso2::enable_traffic_manager_specific_axis2_configurations: false
+wso2::enable_traffic_manager_specific_registry_configurations: false

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-key-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-key-manager.yaml
@@ -25,10 +25,6 @@ wso2::apim_traffic_manager:
   username: "%{hiera('wso2::super_admin::username')}"
   password: "%{hiera('wso2::super_admin::password')}"
 
-wso2::template_list:
-  - repository/conf/axis2/axis2_TM.xml
-  - repository/conf/registry_TM.xml
-
 wso2::clustering:
   enabled: true
   domain: km.am.wso2.domain

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-publisher.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-publisher.yaml
@@ -20,8 +20,10 @@ wso2::template_list:
   - repository/conf/jndi.properties
 
 wso2::apim_traffic_manager:
-  host: km.dev.wso2.org
+  host: tm.dev.wso2.org
   port: 9443
+  receiver_url_port: 9611
+  auth_url_port: 9711
   jms_url_port: 5672
   username: "%{hiera('wso2::super_admin::username')}"
   password: "%{hiera('wso2::super_admin::password')}"
@@ -76,11 +78,13 @@ wso2::sso_authentication:
   sso_service_url: https://is.dev.wso2.org:9443/samlsso
   consumer_service_url: https://pub.dev.wso2.org:9443/acs
 
-# Uncomment the following in a distributed setup, including the trust store with the certificate of the key manager
 wso2::file_list:
   - "repository/resources/security/%{hiera('wso2::trust_store')}"
+
 wso2::enable_thrift_server: false
 wso2::enable_advance_throttling: true
 wso2::enable_data_publisher: false
 wso2::enable_block_condition: false
 wso2::enable_jms_connection_details: false
+wso2::enable_traffic_manager_specific_axis2_configurations: false
+wso2::enable_traffic_manager_specific_registry_configurations: false

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-store.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-store.yaml
@@ -66,7 +66,6 @@ wso2::sso_authentication:
   sso_service_url: https://is.dev.wso2.org:9443/samlsso
   consumer_service_url: https://store.dev.wso2.org:9443/acs
 
-# Uncomment the following in a distributed setup, including the trust store with the certificate of the key manager
 wso2::file_list:
   - "repository/resources/security/%{hiera('wso2::trust_store')}"
 
@@ -75,3 +74,5 @@ wso2::enable_advance_throttling: true
 wso2::enable_data_publisher: false
 wso2::enable_block_condition: false
 wso2::enable_jms_connection_details: false
+wso2::enable_traffic_manager_specific_axis2_configurations: false
+wso2::enable_traffic_manager_specific_registry_configurations: false

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/default.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/default.yaml
@@ -33,7 +33,6 @@ wso2::template_list:
 #    https: 443
 
 ## Uncomment the following in a clustered setup
-#Note : Uncomment the files "wso2::key_store" and "wso2::trust_store" if keymanager and trafficmanager are same node
 wso2::file_list:
   - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
   - "repository/resources/security/%{hiera('wso2::key_store')}"
@@ -44,7 +43,7 @@ wso2::hostname: am.dev.wso2.org
 wso2::mgt_hostname: am.dev.wso2.org
 
 wso2::apim_traffic_manager:
-  host: km.dev.wso2.org
+  host: tm.dev.wso2.org
   port: 9443
   receiver_url_port: 9611
   auth_url_port: 9711
@@ -107,6 +106,9 @@ wso2::hosts_mapping:
   apim_gateway:
     ip: 192.168.100.5
     name: gw.dev.wso2.org
+  apim_traffic_manager:
+    ip: 192.168.100.6
+    name: tm.dev.wso2.org
   svn:
     ip: 192.168.100.1
     name: svn.gw.am.dev.wso2.org
@@ -160,7 +162,7 @@ wso2::master_datasources:
     name: WSO2_MB_STORE_DB
     description: The datasource used for message broker database
     driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
-    url: jdbc:h2:repository/database/WSO2_MB_STORE_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000
+    url: jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000
     username: "%{hiera('wso2::datasources::common::username')}"
     password: "%{hiera('wso2::datasources::common::password')}"
     jndi_config: WSO2MBStoreDB
@@ -216,22 +218,16 @@ wso2::master_datasources:
     validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
     validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
-# Uncomment the following for a clustered setup
 wso2::enable_advance_throttling: true
-# Uncomment the following for a clustered setup
 wso2::enable_thrift_server: true
-# Uncomment the following for a clustered setup
 wso2::thrift_server_host: localhost
-# Uncomment the following for a clustered setup
 wso2::key_validator_client_type: ThriftClient
-# Uncomment the following for a clustered setup
 wso2::enable_data_publisher: false
-# Uncomment the following for a clustered setup
 wso2::enable_block_condition: true
-# Uncomment the following for a clustered setup
 wso2::enable_jms_connection_details: false
-#Set 'apim_gateway_disble_jms_connection_parameters' to 'false' to disable JMS connection parameters in gateway, in disrtributed setup
-wso2::apim_gateway_disble_jms_connection_parameters: false
+wso2::apim_gateway_disable_jms_event_parameters: false
+wso2::enable_traffic_manager_specific_axis2_configurations: false
+wso2::enable_traffic_manager_specific_registry_configurations: false
 
 # Secure vault configuration
 #wso2::enable_secure_vault: true

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/default.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/default.yaml
@@ -32,18 +32,18 @@ wso2::template_list:
 #    http: 80
 #    https: 443
 
-## Uncomment the following in a clustered setup
-wso2::file_list:
-  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
-  - "repository/resources/security/%{hiera('wso2::key_store')}"
-  - "repository/resources/security/%{hiera('wso2::trust_store')}"
+# Uncomment the following in a clustered setup
+#wso2::file_list:
+#  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
+#  - "repository/resources/security/%{hiera('wso2::key_store')}"
+#  - "repository/resources/security/%{hiera('wso2::trust_store')}"
 
 wso2::service_name: wso2am
 wso2::hostname: am.dev.wso2.org
 wso2::mgt_hostname: am.dev.wso2.org
 
 wso2::apim_traffic_manager:
-  host: tm.dev.wso2.org
+  host: am.dev.wso2.org
   port: 9443
   receiver_url_port: 9611
   auth_url_port: 9711
@@ -52,9 +52,9 @@ wso2::apim_traffic_manager:
   password: "%{hiera('wso2::super_admin::password')}"
 
 wso2::apim_gateway:
-  host: gw.dev.wso2.org
+  host: am.dev.wso2.org
   port: 9443
-  api_endpoint_host: gw.dev.wso2.org
+  api_endpoint_host: am.dev.wso2.org
   api_endpoint_port: 8280
   secure_api_endpoint_port: 8243
   api_token_revoke_endpoint_port: 8280
@@ -63,99 +63,99 @@ wso2::apim_gateway:
   password: "%{hiera('wso2::super_admin::password')}"
 
 wso2::apim_keymanager:
-  host: km.dev.wso2.org
+  host: am.dev.wso2.org
   port: 9443
   username: "%{hiera('wso2::super_admin::username')}"
   password: "%{hiera('wso2::super_admin::password')}"
 
 wso2::apim_store:
-  host: store.dev.wso2.org
+  host: am.dev.wso2.org
   port: 9443
 
 wso2::apim_publisher:
-  host: pub.dev.wso2.org
+  host: am.dev.wso2.org
   port: 9443
 
 ## Uncomment the hosts mappings for a clustered setup
-wso2::registry_mounts:
-  wso2_config_db:
-     path: /_system/config
-     target_path: /_system/config/apim
-     read_only: false
-     registry_root: /
-     enable_cache: true
-
-  wso2_gov_db:
-     path: /_system/governance
-     target_path: /_system/governance
-     read_only: false
-     registry_root: /
-     enable_cache: true
+#wso2::registry_mounts:
+#  wso2_config_db:
+#     path: /_system/config
+#     target_path: /_system/config/apim
+#     read_only: false
+#     registry_root: /
+#     enable_cache: true
+#
+#  wso2_gov_db:
+#     path: /_system/governance
+#     target_path: /_system/governance
+#     read_only: false
+#     registry_root: /
+#     enable_cache: true
 
 ## Uncomment the hosts mappings for a clustered setup
-wso2::hosts_mapping:
-  apim_keymanager:
-    ip: 192.168.100.2
-    name: km.dev.wso2.org
-  apim_store:
-    ip: 192.168.100.3
-    name: store.dev.wso2.org
-  apim_publisher:
-    ip: 192.168.100.4
-    name: pub.dev.wso2.org
-  apim_gateway:
-    ip: 192.168.100.5
-    name: gw.dev.wso2.org
-  apim_traffic_manager:
-    ip: 192.168.100.6
-    name: tm.dev.wso2.org
-  svn:
-    ip: 192.168.100.1
-    name: svn.gw.am.dev.wso2.org
+#wso2::hosts_mapping:
+#  apim_keymanager:
+#    ip: 192.168.100.2
+#    name: km.dev.wso2.org
+#  apim_store:
+#    ip: 192.168.100.3
+#    name: store.dev.wso2.org
+#  apim_publisher:
+#    ip: 192.168.100.4
+#    name: pub.dev.wso2.org
+#  apim_gateway:
+#    ip: 192.168.100.5
+#    name: gw.dev.wso2.org
+#  apim_traffic_manager:
+#    ip: 192.168.100.6
+#    name: tm.dev.wso2.org
+#  svn:
+#    ip: 192.168.100.1
+#    name: svn.gw.am.dev.wso2.org
 
 ## Uncomment the following to use MySQL data source in a clustered setup
-wso2::usermgt_datasource: wso2user_db
+#wso2::usermgt_datasource: wso2user_db
 
 # Use H2 based wso2am_db in a stand-alone setup. In a clustered setup this should point to a MySQL data source
 wso2::is_datasource: wso2am_db
 wso2::am_datasource: wso2am_db
 
 ## Uncomment the following key_store and trust_store to include the certificate of keymanager in gateway in a clustered setup
-wso2::key_store: wso2carbon.jks
-wso2::trust_store: client-truststore.jks
+#wso2::key_store: wso2carbon.jks
+#wso2::trust_store: client-truststore.jks
 
-#wso2::am_datasources:
-#  wso2am_db:
-#    name: WSO2AM_DB
-#    description: The datasource used for API Manager database
-#    driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
-#    url: jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE
-#    username: "%{hiera('wso2::datasources::common::username')}"
-#    password: "%{hiera('wso2::datasources::common::password')}"
-#    jndi_config: jdbc/WSO2AM_DB
-#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
-#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
-#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
-#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-#    validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
-#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
-
-## Uncomment the following AM data source and comment out the above H2 data source for a clustered setup
 wso2::am_datasources:
   wso2am_db:
     name: WSO2AM_DB
     description: The datasource used for API Manager database
-    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
-    url: jdbc:mysql://192.168.100.1:3306/APIM_DB?autoReconnect=true
-    username: "%{hiera('wso2::datasources::mysql::username')}"
-    password: "%{hiera('wso2::datasources::mysql::password')}"
+    driver_class_name: "%{hiera('wso2::datasources::h2::driver_class_name')}"
+    url: jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE
+    username: "%{hiera('wso2::datasources::common::username')}"
+    password: "%{hiera('wso2::datasources::common::password')}"
     jndi_config: jdbc/WSO2AM_DB
     max_active: "%{hiera('wso2::datasources::common::max_active')}"
     max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
     test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
     default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+    validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
     validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+
+## Uncomment the following AM data source and comment out the above H2 data source for a clustered setup
+#wso2::am_datasources:
+#  wso2am_db:
+#    name: WSO2AM_DB
+#    description: The datasource used for API Manager database
+#    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+#    url: jdbc:mysql://192.168.100.1:3306/APIM_DB?autoReconnect=true
+#    username: "%{hiera('wso2::datasources::mysql::username')}"
+#    password: "%{hiera('wso2::datasources::mysql::password')}"
+#    jndi_config: jdbc/WSO2AM_DB
+#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+#    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
 wso2::master_datasources:
   wso2_mb_store_db:
@@ -173,52 +173,52 @@ wso2::master_datasources:
     validation_query: "%{hiera('wso2::datasources::h2::validation_query')}"
     validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 # Uncomment the following MySQL data source (wso2_config_db) for a clustered setup
-  wso2_config_db:
-    name: WSO2_CONFIG_DB
-    description: The datasource used for config registry
-    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
-    url: jdbc:mysql://192.168.100.1:3306/WSO2_CONFIG_DB?autoReconnect=true
-    username: "%{hiera('wso2::datasources::mysql::username')}"
-    password: "%{hiera('wso2::datasources::mysql::password')}"
-    jndi_config: jdbc/WSO2_CONFIG_DB
-    max_active: "%{hiera('wso2::datasources::common::max_active')}"
-    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
-    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
-    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
-    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+#  wso2_config_db:
+#    name: WSO2_CONFIG_DB
+#    description: The datasource used for config registry
+#    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+#    url: jdbc:mysql://192.168.100.1:3306/WSO2_CONFIG_DB?autoReconnect=true
+#    username: "%{hiera('wso2::datasources::mysql::username')}"
+#    password: "%{hiera('wso2::datasources::mysql::password')}"
+#    jndi_config: jdbc/WSO2_CONFIG_DB
+#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+#    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 # Uncomment the following MySQL data source (wso2_gov_db) for a clustered setup
-  wso2_gov_db:
-    name: WSO2_GOV_DB
-    description: The datasource used for gov registry
-    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
-    url: jdbc:mysql://192.168.100.1:3306/WSO2REG_DB?autoReconnect=true
-    username: "%{hiera('wso2::datasources::mysql::username')}"
-    password: "%{hiera('wso2::datasources::mysql::password')}"
-    jndi_config: jdbc/WSO2_GOV_DB
-    max_active: "%{hiera('wso2::datasources::common::max_active')}"
-    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
-    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
-    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
-    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+#  wso2_gov_db:
+#    name: WSO2_GOV_DB
+#    description: The datasource used for gov registry
+#    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+#    url: jdbc:mysql://192.168.100.1:3306/WSO2REG_DB?autoReconnect=true
+#    username: "%{hiera('wso2::datasources::mysql::username')}"
+#    password: "%{hiera('wso2::datasources::mysql::password')}"
+#    jndi_config: jdbc/WSO2_GOV_DB
+#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+#    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 # Uncomment the following MySQL data source (wso2user_db) for a clustered setup
-  wso2user_db:
-    name: WSO2USER_DB
-    description: The datasource is used for user mangement and userstore
-    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
-    url: jdbc:mysql://192.168.100.1:3306/WSO2USER_DB?autoReconnect=true
-    username: "%{hiera('wso2::datasources::mysql::username')}"
-    password: "%{hiera('wso2::datasources::mysql::password')}"
-    jndi_config: jdbc/WSO2USER_DB
-    max_active: "%{hiera('wso2::datasources::common::max_active')}"
-    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
-    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
-    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
-    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+#  wso2user_db:
+#    name: WSO2USER_DB
+#    description: The datasource is used for user mangement and userstore
+#    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+#    url: jdbc:mysql://192.168.100.1:3306/WSO2USER_DB?autoReconnect=true
+#    username: "%{hiera('wso2::datasources::mysql::username')}"
+#    password: "%{hiera('wso2::datasources::mysql::password')}"
+#    jndi_config: jdbc/WSO2USER_DB
+#    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+#    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+#    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+#    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+#    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+#    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
 
-wso2::enable_advance_throttling: true
+wso2::enable_advance_throttling: false
 wso2::enable_thrift_server: true
 wso2::thrift_server_host: localhost
 wso2::key_validator_client_type: ThriftClient

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-manager.yaml
@@ -17,7 +17,7 @@ wso2::mgt_hostname: gw.dev.wso2.org
 wso2::hostname: gw.dev.wso2.org
 
 wso2::apim_traffic_manager:
-  host: km.dev.wso2.org
+  host: tm.dev.wso2.org
   port: 9443
   receiver_url_port: 9611
   auth_url_port: 9711
@@ -99,6 +99,6 @@ wso2::file_list:
 wso2::enable_advance_throttling: true
 wso2::enable_data_publisher: true
 wso2::enable_jms_connection_details: true
-
-#Set 'apim_gateway_disble_jms_connection_parameters' to 'true' to disable JMS connection parameters in gateway, in disrtributed setup
-wso2::apim_gateway_disble_jms_connection_parameters: true
+wso2::apim_gateway_disable_jms_event_parameters: true
+wso2::enable_traffic_manager_specific_axis2_configurations: false
+wso2::enable_traffic_manager_specific_registry_configurations: false

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-worker.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-worker.yaml
@@ -17,7 +17,7 @@ wso2::mgt_hostname: mgt.gw.dev.wso2.org
 wso2::hostname: gw.dev.wso2.org
 
 wso2::apim_traffic_manager:
-  host: km.dev.wso2.org
+  host: tm.dev.wso2.org
   port: 9443
   receiver_url_port: 9611
   auth_url_port: 9711
@@ -79,13 +79,12 @@ wso2::registry_mounts:
    enable_cache: true
 
 wso2::enable_thrift_server: false
-
 wso2::thrift_server_host: localhost
-
 wso2::key_validator_client_type: WSClient
 
 wso2::file_list:
   - "repository/resources/security/%{hiera('wso2::trust_store')}"
 
-#Set 'apim_gateway_disble_jms_connection_parameters' to 'true' to disable JMS connection parameters in gateway, in disrtributed setup
-wso2::apim_gateway_disble_jms_connection_parameters: true
+wso2::apim_gateway_disable_jms_event_parameters: true
+wso2::enable_traffic_manager_specific_axis2_configurations: false
+wso2::enable_traffic_manager_specific_registry_configurations: false

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/traffic-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/traffic-manager.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+wso2::mgt_hostname: tm.dev.wso2.org
+wso2::hostname: tm.dev.wso2.org
+
+wso2::template_list:
+  - repository/conf/axis2/axis2.xml
+  - repository/conf/registry.xml
+
+wso2::file_list:
+  - "repository/resources/security/%{hiera('wso2::key_store')}"
+  - "repository/resources/security/%{hiera('wso2::trust_store')}"
+
+wso2::enable_advance_throttling: true
+wso2::enable_thrift_server: true
+wso2::thrift_server_host: localhost
+wso2::key_validator_client_type: ThriftClient
+wso2::enable_data_publisher: false
+wso2::enable_block_condition: true
+wso2::enable_jms_connection_details: false
+wso2::apim_gateway_disable_jms_event_parameters: false
+wso2::enable_traffic_manager_specific_axis2_configurations: true
+wso2::enable_traffic_manager_specific_registry_configurations: true
+

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/traffic-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/traffic-manager.yaml
@@ -16,10 +16,6 @@
 wso2::mgt_hostname: tm.dev.wso2.org
 wso2::hostname: tm.dev.wso2.org
 
-wso2::template_list:
-  - repository/conf/axis2/axis2.xml
-  - repository/conf/registry.xml
-
 wso2::file_list:
   - "repository/resources/security/%{hiera('wso2::key_store')}"
   - "repository/resources/security/%{hiera('wso2::trust_store')}"

--- a/modules/wso2am/manifests/init.pp
+++ b/modules/wso2am/manifests/init.pp
@@ -33,7 +33,9 @@ class wso2am inherits wso2base {
   $enable_data_publisher = hiera('wso2::enable_data_publisher', { })
   $enable_block_condition = hiera('wso2::enable_block_condition', { })
   $enable_jms_connection_details = hiera('wso2::enable_jms_connection_details', { })
-  $apim_gateway_disble_jms_connection_parameters = hiera('wso2::apim_gateway_disble_jms_connection_parameters', "false")
+  $apim_gateway_disable_jms_event_parameters = hiera('wso2::apim_gateway_disable_jms_event_parameters', "false")
+  $enable_traffic_manager_specific_axis2_configurations = hiera('wso2::enable_traffic_manager_specific_axis2_configurations', "false")
+  $enable_traffic_manager_specific_registry_configurations = hiera('wso2::enable_traffic_manager_specific_registry_configurations', "false")
 
   wso2base::server { $wso2base::carbon_home:
     maintenance_mode    => $wso2base::maintenance_mode,

--- a/modules/wso2am/templates/2.0.0/repository/conf/api-manager.xml.erb
+++ b/modules/wso2am/templates/2.0.0/repository/conf/api-manager.xml.erb
@@ -695,24 +695,12 @@
             <%- end -%>
             <Destination>throttleData</Destination>
             <!--InitDelay>300000</InitDelay-->
-            <!-- JMSConnectionParameters must be commented in Gateway(s) in distributed setup -->
-            <%- if @apim_gateway_disble_jms_connection_parameters -%>
-                <!--
-                    <JMSConnectionParameters>
-                        <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
-                        <transport.jms.DestinationType>topic</transport.jms.DestinationType>
-                        <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
-                        <connectionfactory.TopicConnectionFactory>amqp://${jms.username}:${jms.password}@clientid/carbon?brokerlist='${jms.url}'</connectionfactory.TopicConnectionFactory>
-                    </JMSConnectionParameters>
-                -->
-            <%- else -%>
-                <JMSConnectionParameters>
-                    <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
-                    <transport.jms.DestinationType>topic</transport.jms.DestinationType>
-                    <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
-                    <connectionfactory.TopicConnectionFactory>amqp://${jms.username}:${jms.password}@clientid/carbon?brokerlist='${jms.url}'</connectionfactory.TopicConnectionFactory>
-                </JMSConnectionParameters>
-            <%- end -%>
+            <JMSConnectionParameters>
+                <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
+                <transport.jms.DestinationType>topic</transport.jms.DestinationType>
+                <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
+                <connectionfactory.TopicConnectionFactory>amqp://${jms.username}:${jms.password}@clientid/carbon?brokerlist='${jms.url}'</connectionfactory.TopicConnectionFactory>
+            </JMSConnectionParameters>
             <JMSTaskManager>
                 <MinThreadPoolSize>20</MinThreadPoolSize>
                 <MaxThreadPoolSize>100</MaxThreadPoolSize>
@@ -720,14 +708,25 @@
                 <JobQueueSize>10</JobQueueSize>
             </JMSTaskManager>
         </JMSConnectionDetails>
-        <JMSEventPublisherParameters>
-                <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
-                <java.naming.provider.url>repository/conf/jndi.properties</java.naming.provider.url>
-                <transport.jms.DestinationType>topic</transport.jms.DestinationType>
-                <transport.jms.Destination>throttleData</transport.jms.Destination>
-                <transport.jms.ConcurrentPublishers>allow</transport.jms.ConcurrentPublishers>
-                <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
-        </JMSEventPublisherParameters>
+        <%- if @apim_gateway_disable_jms_event_parameters -%>
+            <!--JMSEventPublisherParameters>
+                    <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
+                    <java.naming.provider.url>repository/conf/jndi.properties</java.naming.provider.url>
+                    <transport.jms.DestinationType>topic</transport.jms.DestinationType>
+                    <transport.jms.Destination>throttleData</transport.jms.Destination>
+                    <transport.jms.ConcurrentPublishers>allow</transport.jms.ConcurrentPublishers>
+                    <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
+            </JMSEventPublisherParameters-->
+        <%- else -%>
+            <JMSEventPublisherParameters>
+                    <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
+                    <java.naming.provider.url>repository/conf/jndi.properties</java.naming.provider.url>
+                    <transport.jms.DestinationType>topic</transport.jms.DestinationType>
+                    <transport.jms.Destination>throttleData</transport.jms.Destination>
+                    <transport.jms.ConcurrentPublishers>allow</transport.jms.ConcurrentPublishers>
+                    <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
+            </JMSEventPublisherParameters>
+        <%- end -%>
         <!--DefaultLimits>
             <SubscriptionTierLimits>
                 <Gold>5000</Gold>

--- a/modules/wso2am/templates/2.0.0/repository/conf/axis2/axis2.xml.erb
+++ b/modules/wso2am/templates/2.0.0/repository/conf/axis2/axis2.xml.erb
@@ -1,3 +1,6 @@
+<%- if @enable_traffic_manager_specific_axis2_configurations -%>
+    <%= scope.function_template(["wso2am/2.0.0/repository/conf/axis2/axis2_TM.xml.erb"]) %>
+<%- else -%>
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
   ~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
@@ -946,3 +949,5 @@
     </phaseOrder>
 
 </axisconfig>
+
+<%- end -%>

--- a/modules/wso2am/templates/2.0.0/repository/conf/axis2/axis2_TM.xml.erb
+++ b/modules/wso2am/templates/2.0.0/repository/conf/axis2/axis2_TM.xml.erb
@@ -1,0 +1,731 @@
+<!--
+  ~ Copyright 2005-2011 WSO2, Inc. (http://wso2.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<axisconfig name="AxisJava2.0">
+
+    <!-- ================================================= -->
+    <!-- Globally engaged modules -->
+    <!-- ================================================= -->
+    <module ref="addressing"/>
+
+    <!-- ================================================= -->
+    <!-- Parameters -->
+    <!-- ================================================= -->
+    <parameter name="hotdeployment">${hotdeployment}</parameter>
+    <parameter name="hotupdate">${hotupdate}</parameter>
+    <parameter name="enableMTOM" locked="false">optional</parameter>
+    <parameter name="cacheAttachments">true</parameter>
+    <parameter name="attachmentDIR">work/mtom</parameter>
+    <parameter name="sizeThreshold">4000</parameter>
+
+    <parameter name="EnableChildFirstClassLoading">${childfirstCL}</parameter>
+
+    <!--
+    The exposeServiceMetadata parameter decides whether the metadata (WSDL, schema, policy) of
+    the services deployed on Axis2 should be visible when ?wsdl, ?wsdl2, ?xsd, ?policy requests
+    are received.
+    This parameter can be defined in the axi2.xml file, in which case this will be applicable
+    globally, or in the services.xml files, in which case, it will be applicable to the
+    Service groups and/or services, depending on the level at which the parameter is declared.
+    This value of this parameter defaults to true.
+    -->
+    <parameter name="exposeServiceMetadata">true</parameter>
+
+    <!--If turned on with use the Accept header of the request to determine the contentType of the
+    response-->
+    <parameter name="httpContentNegotiation">true</parameter>
+
+    <!--
+    Defines how the persistence of WS-ReliableMessaging is handled
+
+    Possible value are: inmemory & persistent
+    -->
+    <!-- Following parameter will completely disable REST handling in both the servlets-->
+    <parameter name="disableREST" locked="false">false</parameter>
+
+    <parameter name="Sandesha2StorageManager">inmemory</parameter>
+
+    <!-- This deployment interceptor will be called whenever before a module is initialized or
+     service is deployed -->
+    <listener class="org.wso2.carbon.core.deployment.DeploymentInterceptor"/>
+
+    <!-- setting servicePath. contextRoot is defined in the carbon.xml file -->
+    <!-- modification of this variable should be accompanied by the change in 'ServerURL' in carbon.xml file -->
+    <parameter name="servicePath">services</parameter>
+
+    <!--the directory in which .aar services are deployed inside axis2 repository-->
+    <parameter name="ServicesDirectory">axis2services</parameter>
+
+    <!--the directory in which modules are deployed inside axis2 repository-->
+    <parameter name="ModulesDirectory">axis2modules</parameter>
+
+    <parameter name="userAgent" locked="true">
+        @product.name@-@product.version@
+    </parameter>
+    <parameter name="server" locked="true">
+        @product.name@-@product.version@
+    </parameter>
+
+    <!-- ========================================================================-->
+
+    <!--During a fault, stacktrace can be sent with the fault message. The following flag will control -->
+    <!--that behaviour.-->
+    <parameter name="sendStacktraceDetailsWithFaults">false</parameter>
+
+    <!--If there aren't any information available to find out the fault reason, we set the message of the expcetion-->
+    <!--as the faultreason/Reason. But when a fault is thrown from a service or some where, it will be -->
+    <!--wrapped by different levels. Due to this the initial exception message can be lost. If this flag-->
+    <!--is set then, Axis2 tries to get the first exception and set its message as the faultreason/Reason.-->
+    <parameter name="DrillDownToRootCauseForFaultReason">false</parameter>
+
+    <!--Set the flag to true if you want to enable transport level session mangment-->
+    <parameter name="manageTransportSession">true</parameter>
+
+    <!-- Synapse Configuration file -->
+    <parameter name="SynapseConfig.ConfigurationFile" locked="false">
+        ./repository/deployment/server/synapse-configs
+    </parameter>
+
+    <!-- Synapse Home parameter -->
+    <parameter name="SynapseConfig.HomeDirectory" locked="false">.</parameter>
+
+    <!-- Resolve root used to resolve synapse references like schemas inside a WSDL -->
+    <parameter name="SynapseConfig.ResolveRoot" locked="false">.</parameter>
+
+    <!-- Synapse Server name parameter -->
+    <parameter name="SynapseConfig.ServerName" locked="false">WSO2 Carbon Server</parameter>
+
+    <!--By default, JAXWS services are created by reading annotations. WSDL and schema are generated-->
+    <!--using a separate WSDL generator only when ?wsdl is called. Therefore, even if you engage-->
+    <!--policies etc.. to AxisService, it doesn't appear in the WSDL. By setting the following property-->
+    <!--to true, you can create the AxisService using the generated WSDL and remove the need for a-->
+    <!--WSDL generator. When ?wsdl is called, WSDL is generated in the normal way.-->
+    <parameter name="useGeneratedWSDLinJAXWS">${jaxwsparam}</parameter>
+
+    <!-- Deployer for the dataservice. -->
+    <!--<deployer extension="dbs" directory="dataservices" class="org.wso2.dataservices.DBDeployer"/>-->
+
+    <!-- Axis1 deployer for Axis2-->
+    <!--<deployer extension="wsdd" class="org.wso2.carbon.axis1services.Axis1Deployer" directory="axis1services"/>-->
+
+    <!-- POJO service deployer for Jar -->
+    <!--<deployer extension="jar" class="org.apache.axis2.deployment.POJODeployer" directory="pojoservices"/>-->
+
+    <!-- POJO service deployer for Class  -->
+    <!--<deployer extension="class" class="org.apache.axis2.deployment.POJODeployer" directory="pojoservices"/>-->
+
+    <!-- JAXWS service deployer  -->
+    <!--<deployer extension=".jar" class="org.apache.axis2.jaxws.framework.JAXWSDeployer" directory="servicejars"/>-->
+    <!-- ================================================= -->
+    <!-- Message Receivers -->
+    <!-- ================================================= -->
+    <!--This is the Default Message Receiver for the system , if you want to have MessageReceivers for -->
+    <!--all the other MEP implement it and add the correct entry to here , so that you can refer from-->
+    <!--any operation -->
+    <!--Note : You can ovride this for particular service by adding the same element with your requirement-->
+
+    <messageReceivers>
+        <messageReceiver mep="http://www.w3.org/ns/wsdl/in-only"
+                         class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        <messageReceiver mep="http://www.w3.org/ns/wsdl/robust-in-only"
+                         class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        <messageReceiver mep="http://www.w3.org/ns/wsdl/in-out"
+                         class="org.apache.axis2.rpc.receivers.RPCMessageReceiver"/>
+    </messageReceivers>
+
+    <messageFormatters>
+        <messageFormatter contentType="application/x-www-form-urlencoded"
+                          class="org.apache.axis2.transport.http.XFormURLEncodedFormatter"/>
+        <messageFormatter contentType="multipart/form-data"
+                          class="org.apache.axis2.transport.http.MultipartFormDataFormatter"/>
+        <messageFormatter contentType="application/xml"
+                          class="org.apache.axis2.transport.http.ApplicationXMLFormatter"/>
+        <messageFormatter contentType="text/xml"
+                          class="org.apache.axis2.transport.http.SOAPMessageFormatter"/>
+        <messageFormatter contentType="application/soap+xml"
+                          class="org.apache.axis2.transport.http.SOAPMessageFormatter"/>
+
+        <!--JSON Message Formatters-->
+        <!--messageFormatter contentType="application/json"
+                          class="org.apache.axis2.json.JSONMessageFormatter"/-->
+        <messageFormatter contentType="application/json"
+                                  class="org.apache.axis2.json.gson.JsonFormatter" />
+        <messageFormatter contentType="application/json/badgerfish"
+                          class="org.apache.axis2.json.JSONBadgerfishMessageFormatter"/>
+        <!--messageFormatter contentType="text/javascript"
+                          class="org.apache.axis2.json.JSONMessageFormatter"/-->
+        <messageFormatter contentType="text/javascript"
+                                  class="org.apache.axis2.json.gson.JsonFormatter" />
+
+        <!--messageFormatter contentType="application/x-www-form-urlencoded"
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+        <!--messageFormatter contentType="multipart/form-data"
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+        <!--messageFormatter contentType="application/xml"
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+        <!--messageFormatter contentType="text/html"
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+        <!--messageFormatter contentType="application/soap+xml"
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+        <!--messageFormatter contentType="x-application/hessian"
+			class="org.apache.synapse.format.hessian.HessianMessageFormatter"/-->
+        <!--<messageFormatter contentType="">
+			class="org.apache.synapse.format.hessian.HessianMessageFormatter"/-->
+    </messageFormatters>
+
+    <messageBuilders>
+        <messageBuilder contentType="application/xml"
+                        class="org.apache.axis2.builder.ApplicationXMLBuilder"/>
+        <messageBuilder contentType="application/x-www-form-urlencoded"
+                        class="org.apache.axis2.builder.XFormURLEncodedBuilder"/>
+        <messageBuilder contentType="multipart/form-data"
+                        class="org.apache.axis2.builder.MultipartFormDataBuilder"/>
+
+        <!--JSON Message Builders-->
+        <!--messageBuilder contentType="application/json"
+                        class="org.apache.axis2.json.JSONOMBuilder"/-->
+        <messageBuilder contentType="application/json"
+                                class="org.apache.axis2.json.gson.JsonBuilder" />
+        <messageBuilder contentType="application/json/badgerfish"
+                        class="org.apache.axis2.json.JSONBadgerfishOMBuilder"/>
+        <!--messageBuilder contentType="text/javascript"
+                        class="org.apache.axis2.json.JSONOMBuilder"/-->
+        <messageBuilder contentType="text/javascript"
+                                class="org.apache.axis2.json.gson.JsonBuilder" />
+
+        <!--messageBuilder contentType="application/xml"
+     		        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageBuilder contentType="application/x-www-form-urlencoded"
+                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageBuilder contentType="multipart/form-data"
+                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageBuilder contentType="multipart/related"
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageBuilder contentType="application/soap+xml"
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageBuilder contentType="text/plain"
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageBuilder contentType="text/xml"
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <!--messageFormatter contentType="text/plain"
+                        class="org.apache.axis2.format.PlainTextBuilder"/-->
+        <!--messageBuilder contentType="x-application/hessian"
+		       class="org.apache.synapse.format.hessian.HessianMessageBuilder"/-->
+    </messageBuilders>
+
+
+    <!-- ================================================= -->
+    <!-- In Transports -->
+    <!-- ================================================= -->
+    <transportReceiver name="http"
+                       class="org.wso2.carbon.core.transports.http.HttpTransportListener">
+        <!--
+           Uncomment the following if you are deploying this within an application server. You
+           need to specify the HTTP port of the application server
+        -->
+        <parameter name="port">9763</parameter>
+
+        <!--
+       Uncomment the following to enable any proxy like Apache2 mod_proxy or any load balancer. The port on the proxy server like Apache is 80
+       in this case.
+        -->
+        <!--<parameter name="proxyPort">80</parameter>-->
+    </transportReceiver>
+
+    <!--Please uncomment this in Multiple Instance Scenario if you want to use NIO Transport Recievers and 
+ 	Remove the current transport REceivers in axis2.xml -->
+    <!--transportReceiver name="http" class="org.apache.synapse.transport.nhttp.HttpCoreNIOListener">
+        <parameter name="port" locked="false">8280</parameter>
+        <parameter name="non-blocking" locked="false">true</parameter>
+    </transportReceiver>
+    
+    <transportReceiver name="https" class="org.apache.synapse.transport.nhttp.HttpCoreNIOSSLListener">
+        <parameter name="port" locked="false">8243</parameter>
+        <parameter name="non-blocking" locked="false">true</parameter>
+        <parameter name="keystore" locked="false">
+            <KeyStore>
+                <Location>repository/resources/security/wso2carbon.jks</Location>
+                <Type>JKS</Type>
+                <Password>wso2carbon</Password>
+                <KeyPassword>wso2carbon</KeyPassword>
+            </KeyStore>
+        </parameter>
+        <parameter name="truststore" locked="false">
+            <TrustStore>
+                <Location>repository/resources/security/client-truststore.jks</Location>
+                <Type>JKS</Type>
+                <Password>wso2carbon</Password>
+            </TrustStore>
+        </parameter>
+    </transportReceiver-->
+
+
+    <transportReceiver name="https"
+                       class="org.wso2.carbon.core.transports.http.HttpsTransportListener">
+        <!--
+           Uncomment the following if you are deploying this within an application server. You
+           need to specify the HTTPS port of the application server
+        -->
+        <parameter name="port">9443</parameter>
+
+        <!--
+       Uncomment the following to enable any proxy like Apache2 mod_proxy or any load balancer. The port on a proxy server like Apache is 443
+       in this case.
+        -->
+        <!--<parameter name="proxyPort">443</parameter>-->
+    </transportReceiver>
+
+    <!--
+       Uncomment the following segment to enable TCP transport.
+       Note : Addressing module should be engaged for TCP transport to work
+    -->
+    <!--<transportReceiver name="tcp"
+                       class="org.apache.axis2.transport.tcp.TCPServer">
+        <parameter name="port">6667</parameter>
+    </transportReceiver>-->
+
+    <!--
+     To Enable Mail Transport Listener, please uncomment the following.
+    -->
+    <!--<transportReceiver name="mailto" class="org.apache.axis2.transport.mail.MailTransportListener">
+
+    </transportReceiver>-->
+
+
+    <!--
+      Uncomment this and configure as appropriate for JMS transport support,
+      after setting up your JMS environment (e.g. ActiveMQ)
+    -->
+    <!--<transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+        <parameter name="myTopicConnectionFactory">
+        	<parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+        	<parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+        	<parameter name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</parameter>
+        </parameter>
+
+        <parameter name="myQueueConnectionFactory">
+        	<parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+        	<parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+        	<parameter name="transport.jms.ConnectionFactoryJNDIName">QueueConnectionFactory</parameter>
+        </parameter>
+
+        <parameter name="default">
+        	<parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+        	<parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+        	<parameter name="transport.jms.ConnectionFactoryJNDIName">QueueConnectionFactory</parameter>
+        </parameter>
+    </transportReceiver>-->
+
+    <!--Uncomment this and configure as appropriate for JMS transport support with Apache Qpid -->
+    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+        <parameter name="myTopicConnectionFactory" locked="false">
+            <parameter name="java.naming.factory.initial" locked="false">org.apache.qpid.jndi.PropertiesFileInitialContextFactory</parameter>
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">TopicConnectionFactory</parameter>
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">topic</parameter>
+        </parameter>
+
+        <parameter name="myQueueConnectionFactory" locked="false">
+            <parameter name="java.naming.factory.initial" locked="false">org.apache.qpid.jndi.PropertiesFileInitialContextFactory</parameter>
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+        </parameter>
+
+        <parameter name="default" locked="false">
+            <parameter name="java.naming.factory.initial" locked="false">org.apache.qpid.jndi.PropertiesFileInitialContextFactory</parameter>
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+        </parameter>
+    </transportReceiver-->
+
+    <!--Uncomment this and configure as appropriate for JMS transport support with WSO2 MB 2.x.x -->
+    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+        <parameter name="myTopicConnectionFactory" locked="false">
+           <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">TopicConnectionFactory</parameter>
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">topic</parameter>
+        </parameter>
+
+        <parameter name="myQueueConnectionFactory" locked="false">
+            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+           <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+        </parameter>
+
+        <parameter name="default" locked="false">
+            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+        </parameter>
+    </transportReceiver-->
+
+
+    <!-- ================================================= -->
+    <!-- Out Transports -->
+    <!-- ================================================= -->
+
+    <!--transportSender name="tcp"
+                     class="org.apache.axis2.transport.tcp.TCPTransportSender"/-->
+    <transportReceiver name="local"
+                       class="org.wso2.carbon.core.transports.local.CarbonLocalTransportReceiver"/>
+    <transportSender name="local"
+                     class="org.wso2.carbon.core.transports.local.CarbonLocalTransportSender"/>
+    <!--<transportSender name="jms"
+                     class="org.apache.axis2.transport.jms.JMSSender"/>-->
+    <transportSender name="http"
+                     class="org.apache.axis2.transport.http.CommonsHTTPTransportSender">
+        <parameter name="PROTOCOL">HTTP/1.1</parameter>
+        <parameter name="Transfer-Encoding">chunked</parameter>
+        <!-- This parameter has been added to overcome problems encounted in SOAP action parameter -->
+        <parameter name="OmitSOAP12Action">true</parameter>
+    </transportSender>
+    <transportSender name="https"
+                     class="org.apache.axis2.transport.http.CommonsHTTPTransportSender">
+        <parameter name="PROTOCOL">HTTP/1.1</parameter>
+        <parameter name="Transfer-Encoding">chunked</parameter>
+        <!-- This parameter has been added to overcome problems encounted in SOAP action parameter -->
+        <parameter name="OmitSOAP12Action">true</parameter>
+    </transportSender>
+
+    <!-- To enable mail transport sender, ncomment the following and change the parameters
+         accordingly-->
+    <!--<transportSender name="mailto"
+                     class="org.apache.axis2.transport.mail.MailTransportSender">
+        <parameter name="mail.smtp.from">wso2demomail@gmail.com</parameter>
+        <parameter name="mail.smtp.user">wso2demomail</parameter>
+        <parameter name="mail.smtp.password">mailpassword</parameter>
+        <parameter name="mail.smtp.host">smtp.gmail.com</parameter>
+
+        <parameter name="mail.smtp.port">587</parameter>
+        <parameter name="mail.smtp.starttls.enable">true</parameter>
+        <parameter name="mail.smtp.auth">true</parameter>
+    </transportSender>-->
+
+    <!--Please uncomment this in Multiple Instance Scenario if you want to use NIO sender -->
+    <!--  
+    <transportSender name="http" class="org.apache.synapse.transport.nhttp.HttpCoreNIOSender">
+        <parameter name="non-blocking" locked="false">true</parameter>
+    </transportSender>
+    <transportSender name="https" class="org.apache.synapse.transport.nhttp.HttpCoreNIOSSLSender">
+        <parameter name="non-blocking" locked="false">true</parameter>
+        <parameter name="keystore" locked="false">
+            <KeyStore>
+                <Location>repository/resources/security/wso2carbon.jks</Location>
+                <Type>JKS</Type>
+                <Password>wso2carbon</Password>
+                <KeyPassword>wso2carbon</KeyPassword>
+            </KeyStore>
+        </parameter>
+        <parameter name="truststore" locked="false">
+            <TrustStore>
+                <Location>repository/resources/security/client-truststore.jks</Location>
+                <Type>JKS</Type>
+                <Password>wso2carbon</Password>
+            </TrustStore>
+        </parameter>
+    </transportSender>
+	-->
+
+
+    <!-- ================================================= -->
+    <!-- Phases  -->
+    <!-- ================================================= -->
+    <phaseOrder type="InFlow">
+        <!--  System pre defined phases       -->
+        <!--
+           The MsgInObservation phase is used to observe messages as soon as they are
+           received. In this phase, we could do some things such as SOAP message tracing & keeping
+           track of the time at which a particular message was received
+
+           NOTE: This should be the very first phase in this flow
+        -->
+        <phase name="MsgInObservation"/>
+
+        <phase name="Validation"/>
+        <phase name="Transport">
+            <handler name="RequestURIBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher">
+                <order phase="Transport"/>
+            </handler>
+            <handler name="SOAPActionBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher">
+                <order phase="Transport"/>
+            </handler>
+            <handler name="RequestURIOperationDispatcher"
+                     class="org.apache.axis2.dispatchers.RequestURIOperationDispatcher" />
+            <handler name="JSONMessageHandler"
+                     class="org.apache.axis2.json.gson.JSONMessageHandler" />
+        </phase>
+        <phase name="Addressing">
+            <handler name="AddressingBasedDispatcher"
+                     class="org.wso2.carbon.core.multitenancy.MultitenantAddressingBasedDispatcher">
+                <order phase="Addressing"/>
+            </handler>
+        </phase>
+        <phase name="Ghost">
+            <handler name="GhostDispatcher"
+                     class="org.wso2.carbon.core.dispatchers.GhostDispatcher"/>
+        </phase>
+        <phase name="Security"/>
+        <phase name="PreDispatch"/>
+        <phase name="Dispatch" class="org.apache.axis2.engine.DispatchPhase">
+            <handler name="RequestURIBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher"/>
+            <handler name="SOAPActionBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher"/>
+            <handler name="SOAPMessageBodyBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.SOAPMessageBodyBasedDispatcher"/>
+
+            <handler name="HTTPLocationBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.HTTPLocationBasedDispatcher"/>
+        </phase>
+        <!--  System pre defined phases       -->
+        <phase name="RMPhase"/>
+        <phase name="OpPhase"/>
+        <!--   After Postdispatch phase module author or or service author can add any phase he want      -->
+        <phase name="OperationInPhase"/>
+    </phaseOrder>
+    <phaseOrder type="OutFlow">
+        <!-- Handlers related to unified-endpoint component are added to the UEPPhase -->
+        <phase name="UEPPhase"/>
+        <phase name="RMPhase"/>
+        <phase name="OpPhase"/>
+        <!--      user can add his own phases to this area  -->
+        <phase name="OperationOutPhase"/>
+        <!--system predefined phase-->
+        <!--these phase will run irrespective of the service-->
+        <phase name="PolicyDetermination"/>
+        <phase name="MessageOut"/>
+        <phase name="Security"/>
+
+        <!--
+           The MsgOutObservation phase is used to observe messages just before the
+           responses are sent out. In this phase, we could do some things such as SOAP message
+           tracing & keeping track of the time at which a particular response was sent.
+
+           NOTE: This should be the very last phase in this flow
+        -->
+        <phase name="MsgOutObservation"/>
+        <!--Following phase is added to publish stats -->
+        <phase name="StatReporting"/>
+    </phaseOrder>
+    <phaseOrder type="InFaultFlow">
+        <!--  System pre defined phases       -->
+        <!--
+           The MsgInObservation phase is used to observe messages as soon as they are
+           received. In this phase, we could do some things such as SOAP message tracing & keeping
+           track of the time at which a particular message was received
+
+           NOTE: This should be the very first phase in this flow
+        -->
+        <phase name="MsgInObservation"/>
+
+        <phase name="Validation"/>
+        <phase name="Transport">
+            <handler name="RequestURIBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher">
+                <order phase="Transport"/>
+            </handler>
+            <handler name="SOAPActionBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher">
+                <order phase="Transport"/>
+            </handler>
+        </phase>
+
+        <phase name="Addressing">
+            <handler name="AddressingBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.AddressingBasedDispatcher">
+                <order phase="Addressing"/>
+            </handler>
+        </phase>
+        <phase name="Ghost">
+            <handler name="GhostDispatcher"
+                     class="org.wso2.carbon.core.dispatchers.GhostDispatcher"/>
+        </phase>
+        <phase name="Security"/>
+        <phase name="PreDispatch"/>
+        <phase name="Dispatch" class="org.apache.axis2.engine.DispatchPhase">
+            <handler name="RequestURIBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher"/>
+            <handler name="SOAPActionBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher"/>
+            <handler name="SOAPMessageBodyBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.SOAPMessageBodyBasedDispatcher"/>
+
+            <handler name="HTTPLocationBasedDispatcher"
+                     class="org.apache.axis2.dispatchers.HTTPLocationBasedDispatcher"/>
+        </phase>
+        <phase name="RMPhase"/>
+        <phase name="OpPhase"/>
+        <!--      user can add his own phases to this area  -->
+        <phase name="OperationInFaultPhase"/>
+    </phaseOrder>
+    <phaseOrder type="OutFaultFlow">
+        <!-- Handlers related to unified-endpoint component are added to the UEPPhase -->
+        <phase name="UEPPhase"/>
+        <phase name="RMPhase"/>
+        <!--      user can add his own phases to this area  -->
+        <phase name="OperationOutFaultPhase"/>
+        <phase name="PolicyDetermination"/>
+        <phase name="MessageOut"/>
+        <phase name="Security"/>
+	<phase name="Transport"/>
+        <!--
+           The MsgOutObservation phase is used to observe messages just before the
+           responses are sent out. In this phase, we could do some things such as SOAP message
+           tracing & keeping track of the time at which a particular response was sent.
+
+           NOTE: This should be the very last phase in this flow
+        -->
+        <phase name="MsgOutObservation"/>
+        <!--Following phase is added to publish stats -->
+        <phase name="StatReporting"/>
+    </phaseOrder>
+
+    <clustering class="org.wso2.carbon.core.clustering.hazelcast.HazelcastClusteringAgent"
+                enable="false">
+
+        <!--
+           This parameter indicates whether the cluster has to be automatically initalized
+           when the AxisConfiguration is built. If set to "true" the initialization will not be
+           done at that stage, and some other party will have to explictly initialize the cluster.
+        -->
+        <parameter name="AvoidInitiation">true</parameter>
+
+        <!--
+           The membership scheme used in this setup. The only values supported at the moment are
+           "multicast" and "wka"
+
+           1. multicast - membership is automatically discovered using multicasting
+           2. wka - Well-Known Address based multicasting. Membership is discovered with the help
+                    of one or more nodes running at a Well-Known Address. New members joining a
+                    cluster will first connect to a well-known node, register with the well-known node
+                    and get the membership list from it. When new members join, one of the well-known
+                    nodes will notify the others in the group. When a member leaves the cluster or
+                    is deemed to have left the cluster, it will be detected by the Group Membership
+                    Service (GMS) using a TCP ping mechanism.
+        -->
+        <parameter name="membershipScheme">multicast</parameter>
+        <!--<parameter name="licenseKey">xxx</parameter>-->
+        <!--<parameter name="mgtCenterURL">http://localhost:8081/mancenter/</parameter>-->
+
+        <!--
+         The clustering domain/group. Nodes in the same group will belong to the same multicast
+         domain. There will not be interference between nodes in different groups.
+        -->
+        <parameter name="domain">wso2.carbon.domain</parameter>
+
+        <!-- The multicast address to be used -->
+        <!--<parameter name="mcastAddress">228.0.0.4</parameter>-->
+
+        <!-- The multicast port to be used -->
+        <parameter name="mcastPort">45564</parameter>
+
+        <parameter name="mcastTTL">100</parameter>
+
+        <parameter name="mcastTimeout">60</parameter>
+
+        <!--
+           The IP address of the network interface to which the multicasting has to be bound to.
+           Multicasting would be done using this interface.
+        -->
+        <!--
+            <parameter name="mcastBindAddress">127.0.0.1</parameter>
+        -->
+        <!-- The host name or IP address of this member -->
+
+        <parameter name="localMemberHost">127.0.0.1</parameter>
+
+        <!--
+            The bind adress of this member. The difference between localMemberHost & localMemberBindAddress
+            is that localMemberHost is the one that is advertised by this member, while localMemberBindAddress
+            is the address to which this member is bound to.
+        -->
+        <!--
+        <parameter name="localMemberBindAddress">127.0.0.1</parameter>
+        -->
+
+        <!--
+        The TCP port used by this member. This is the port through which other nodes will
+        contact this member
+         -->
+        <parameter name="localMemberPort">4000</parameter>
+
+        <!--
+            The bind port of this member. The difference between localMemberPort & localMemberBindPort
+            is that localMemberPort is the one that is advertised by this member, while localMemberBindPort
+            is the port to which this member is bound to.
+        -->
+        <!--
+        <parameter name="localMemberBindPort">4001</parameter>
+        -->
+
+        <!--
+        Properties specific to this member
+        -->
+        <parameter name="properties">
+            <property name="backendServerURL" value="https://${hostName}:${httpsPort}/services/"/>
+            <property name="mgtConsoleURL" value="https://${hostName}:${httpsPort}/"/>
+            <property name="subDomain" value="worker"/>
+        </parameter>
+
+        <!--
+        Uncomment the following section to load custom Hazelcast data serializers.
+        -->
+        <!--
+        <parameter name="hazelcastSerializers">
+            <serializer typeClass="java.util.TreeSet">org.wso2.carbon.hazelcast.serializer.TreeSetSerializer
+            </serializer>
+            <serializer typeClass="java.util.Map">org.wso2.carbon.hazelcast.serializer.MapSerializer</serializer>
+        </parameter>
+        -->
+
+        <parameter name="hazelcastSerializers">
+            <serializer typeClass="org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.wrapper.TreeSetLongWrapper">org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.TreeSetLongWrapperSerializer</serializer>
+            <serializer typeClass="org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.wrapper.TreeSetSlotWrapper">org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.TreeSetSlotWrapperSerializer</serializer>
+            <serializer typeClass="org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.wrapper.HashmapStringTreeSetWrapper">org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.HashMapStringTreeSetWrapperSerializer</serializer>
+        </parameter>
+
+        <!--
+           The list of static or well-known members. These entries will only be valid if the
+           "membershipScheme" above is set to "wka"
+        -->
+        <members>
+            <member>
+                <hostName>127.0.0.1</hostName>
+                <port>4000</port>
+            </member>
+        </members>
+
+        <!--
+        Enable the groupManagement entry if you need to run this node as a cluster manager.
+        Multiple application domains with different GroupManagementAgent implementations
+        can be defined in this section.
+        -->
+        <groupManagement enable="false">
+            <applicationDomain name="wso2.as.domain"
+                               description="AS group"
+                               agent="org.wso2.carbon.core.clustering.hazelcast.HazelcastGroupManagementAgent"
+                               subDomain="worker"
+                               port="2222"/>
+        </groupManagement>
+    </clustering>
+</axisconfig>

--- a/modules/wso2am/templates/2.0.0/repository/conf/registry.xml.erb
+++ b/modules/wso2am/templates/2.0.0/repository/conf/registry.xml.erb
@@ -1,3 +1,6 @@
+<%- if @enable_traffic_manager_specific_registry_configurations -%>
+    <%= scope.function_template(["wso2am/2.0.0/repository/conf/registry_TM.xml.erb"]) %>
+<%- else -%>
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
 <!--
@@ -373,3 +376,5 @@
     </tasks-->
 
 </wso2registry>
+
+<%- end -%>

--- a/modules/wso2am/templates/2.0.0/repository/conf/registry_TM.xml.erb
+++ b/modules/wso2am/templates/2.0.0/repository/conf/registry_TM.xml.erb
@@ -1,0 +1,141 @@
+<!--
+  ~ Copyright 2005-2011 WSO2, Inc. (http://wso2.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<wso2registry>
+
+    <!--
+    For details on configuring different config & governance registries see;
+    http://wso2.org/library/tutorials/2010/04/sharing-registry-space-across-multiple-product-instances
+    -->
+
+    <currentDBConfig>wso2registry</currentDBConfig>
+    <readOnly>false</readOnly>
+    <enableCache>true</enableCache>
+    <registryRoot>/</registryRoot>
+
+    <dbConfig name="wso2registry">
+        <dataSource>jdbc/WSO2CarbonDB</dataSource>
+    </dbConfig>
+
+    <indexingConfiguration>
+        <startIndexing>true</startIndexing>
+        <startingDelayInSeconds>35</startingDelayInSeconds>
+        <indexingFrequencyInSeconds>5</indexingFrequencyInSeconds>
+        <!--number of resources submit for given indexing thread -->
+        <batchSize>30</batchSize>
+        <!--number of worker threads for indexing -->
+        <indexerPoolSize>30</indexerPoolSize>
+        <!-- location storing the time the indexing took place-->
+        <lastAccessTimeLocation>
+            /_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime
+        </lastAccessTimeLocation>
+        <!-- the indexers that implement the indexer interface for a relevant media type/(s) -->
+        <indexers>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.MSExcelIndexer"
+                     mediaTypeRegEx="application/vnd.ms-excel"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.MSPowerpointIndexer"
+                     mediaTypeRegEx="application/vnd.ms-powerpoint"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.MSWordIndexer"
+                     mediaTypeRegEx="application/msword"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PDFIndexer"
+                     mediaTypeRegEx="application/pdf"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.XMLIndexer"
+                     mediaTypeRegEx="application/xml"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.XMLIndexer"
+                     mediaTypeRegEx="application/(.)+\+xml"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer"
+                     mediaTypeRegEx="application/swagger\+json"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer"
+                     mediaTypeRegEx="application/(.)+\+json"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer"
+                     mediaTypeRegEx="text/(.)+"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer"
+                     mediaTypeRegEx="application/x-javascript"/>
+        </indexers>
+        <exclusions>
+            <exclusion
+                    pathRegEx="/_system/config/repository/dashboards/gadgets/swfobject1-5/.*[.]html"/>
+            <exclusion
+                    pathRegEx="/_system/local/repository/components/org[.]wso2[.]carbon[.]registry/mount/.*"/>
+        </exclusions>
+    </indexingConfiguration>
+
+    <!--<handler class="org.wso2.carbon.registry.extensions.handlers.SynapseRepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.synapse</property>
+        </filter>
+    </handler>
+
+    <handler class="org.wso2.carbon.registry.extensions.handlers.SynapseRepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.esb</property>
+        </filter>
+    </handler>
+
+    <handler class="org.wso2.carbon.registry.extensions.handlers.Axis2RepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.axis2</property>
+        </filter>
+    </handler>
+
+    <handler class="org.wso2.carbon.registry.extensions.handlers.Axis2RepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.wsas</property>
+        </filter>
+    </handler>
+
+    <handler class="org.wso2.carbon.registry.extensions.handlers.WSDLMediaTypeHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/wsdl+xml</property>
+        </filter>
+    </handler>
+
+    <handler class="org.wso2.carbon.registry.extensions.handlers.XSDMediaTypeHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/x-xsd+xml</property>
+        </filter>
+    </handler> -->
+
+    <!--remoteInstance url="https://localhost:9443/registry">
+        <id>instanceid</id>
+        <username>username</username>
+        <password>password</password>
+    </remoteInstance-->
+
+    <!--remoteInstance url="https://localhost:9443/registry">
+        <id>instanceid</id>
+        <dbConfig>wso2registry</dbConfig>
+        <readOnly>false</readOnly>
+        <enableCache>true</enableCache>
+        <registryRoot>/</registryRoot>
+    </remoteInstance-->
+
+    <!--mount path="/_system/config" overwrite="true|false|virtual">
+        <instanceId>instanceid</instanceId>
+        <targetPath>/_system/nodes</targetPath>
+    </mount-->
+
+
+    <versionResourcesOnChange>false</versionResourcesOnChange>
+
+    <!-- NOTE: You can edit the options under "StaticConfiguration" only before the
+     startup. -->
+    <staticConfiguration>
+        <versioningProperties>true</versioningProperties>
+        <versioningComments>true</versioningComments>
+        <versioningTags>true</versioningTags>
+        <versioningRatings>true</versioningRatings>
+    </staticConfiguration>
+</wso2registry>

--- a/vagrant/samples/wso2am/wso2am-2.0.0-distributed.config.yaml
+++ b/vagrant/samples/wso2am/wso2am-2.0.0-distributed.config.yaml
@@ -15,21 +15,32 @@
 ---
 servers:
 
-# Note : "km.dev.wso2.org" should have the "default" profile since it is acting as the keymanager and traffic manager
   -
     enabled: true
     hostname: km.dev.wso2.org
     facters:
       product_name: wso2am
       product_version: 2.0.0
-      product_profile: default
+      product_profile: api-key-manager
       environment: dev
       platform: default
     box: ubuntu/trusty64
     ip: 192.168.100.2
     ram: 2048
     cpu: 1
-
+  -
+    enabled: true
+    hostname: tm.dev.wso2.org
+    facters:
+      product_name: wso2am
+      product_version: 2.0.0
+      product_profile: traffic-manager
+      environment: dev
+      platform: default
+    box: ubuntu/trusty64
+    ip: 192.168.100.6
+    ram: 2048
+    cpu: 1
   -
     enabled: true
     hostname: store.dev.wso2.org
@@ -43,7 +54,6 @@ servers:
     ip: 192.168.100.3
     ram: 2048
     cpu: 1
-
   -
     enabled: true
     hostname: publisher.dev.wso2.org
@@ -57,7 +67,6 @@ servers:
     ip: 192.168.100.4
     ram: 2048
     cpu: 1
-
   -
     enabled: true
     hostname: gw.dev.wso2.org
@@ -71,3 +80,4 @@ servers:
     ip: 192.168.100.5
     ram: 2048
     cpu: 1
+


### PR DESCRIPTION
Note : 

With the newly introduced "traffic manager" profile in API Manager 2.0.0, there is a requirement to support file deletion in puppet scripts. Once this new profile is introduced, it is needed to remove existing webapps and jaggeryapps from the <APIM_HOME>/repository/deployment/server directory. Otherwise it will throw exceptions at the startup of the traffic manager node.
If we remove the required files manually (by logging in to traffic manager node, execute "rm -r webapps" and "rm -r jaggeryapps" and restarting it), those exceptions are not going to be there.
Please refer [1] for more information.

[1] https://docs.wso2.com/display/CLUSTER44x/Clustering+API+Manager+2.0.0#ClusteringAPIManager2.0.0-ConfiguringtheTrafficManager

JIRA for this : https://wso2.org/jira/browse/PMODULES-24
