### PR TITLE
Fixing enable analytics node.size to nodes.size

### DIFF
--- a/modules/wso2am/templates/1.10.0/repository/conf/api-manager.xml.erb
+++ b/modules/wso2am/templates/1.10.0/repository/conf/api-manager.xml.erb
@@ -268,7 +268,7 @@
                  {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/}
         -->
         <DASServerURL><%- @apim_analytics['das_cluster'].each_with_index  do |(group,nodes),n| -%>{<%- nodes
-        .each_with_index do |node,i| -%>tcp://<%= node['hostname'] %>:<%= node['port'] %> <%= ',' if i <(node.size -
+        .each_with_index do |node,i| -%>tcp://<%= node['hostname'] %>:<%= node['port'] %> <%= ',' if i <(nodes.size -
         1) %><%- end -%>}<%= ',' if n <(@apim_analytics['das_cluster'].size - 1) %><%- end -%></DASServerURL>
 
         <!--

--- a/modules/wso2am/templates/2.0.0/repository/conf/api-manager.xml.erb
+++ b/modules/wso2am/templates/2.0.0/repository/conf/api-manager.xml.erb
@@ -210,7 +210,7 @@
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
         <DASServerURL><%- @apim_analytics['das_cluster'].each_with_index  do |(group,nodes),n| -%>{<%- nodes
-        .each_with_index do |node,i| -%>tcp://<%= node['hostname'] %>:<%= node['port'] %> <%= ',' if i <(node.size -
+        .each_with_index do |node,i| -%>tcp://<%= node['hostname'] %>:<%= node['port'] %> <%= ',' if i <(nodes.size -
         1) %><%- end -%>}<%= ',' if n <(@apim_analytics['das_cluster'].size - 1) %><%- end -%></DASServerURL>
 
         <!--DASAuthServerURL>{ssl://<%= @apim_analytics['das_auth_server'] %>:<%= @apim_analytics['das_auth_port


### PR DESCRIPTION
This commit is intended to remove the extra "," character addition to the api-manager.xml. This was due to it was referring to node list in place of nodes list. 