### PR TITLE
change the config registry mount path to same location

### DIFF
--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-key-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-key-manager.yaml
@@ -52,7 +52,7 @@ wso2::clustering:
 wso2::registry_mounts:
  wso2_config_db:
    path: /_system/config
-   target_path: /_system/config/apim-km
+   target_path: /_system/config
    read_only: false
    registry_root: /
    enable_cache: true

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-publisher.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-publisher.yaml
@@ -58,7 +58,7 @@ wso2::clustering:
 wso2::registry_mounts:
  wso2_config_db:
    path: /_system/config
-   target_path: /_system/config/apim-pub
+   target_path: /_system/config
    read_only: false
    registry_root: /
    enable_cache: true

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/api-store.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/api-store.yaml
@@ -46,7 +46,7 @@ wso2::clustering:
 wso2::registry_mounts:
  wso2_config_db:
    path: /_system/config
-   target_path: /_system/config/apim-store
+   target_path: /_system/config
    read_only: false
    registry_root: /
    enable_cache: true

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/default.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/default.yaml
@@ -80,7 +80,7 @@ wso2::apim_publisher:
 #wso2::registry_mounts:
 #  wso2_config_db:
 #     path: /_system/config
-#     target_path: /_system/config/apim
+#     target_path: /_system/config
 #     read_only: false
 #     registry_root: /
 #     enable_cache: true

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-manager.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-manager.yaml
@@ -67,7 +67,7 @@ wso2::dep_sync:
 wso2::registry_mounts:
  wso2_config_db:
    path: /_system/config
-   target_path: /_system/config/apim-gw
+   target_path: /_system/config
    read_only: false
    registry_root: /
    enable_cache: true

--- a/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-worker.yaml
+++ b/hieradata/dev/wso2/wso2am/2.0.0/default/gateway-worker.yaml
@@ -66,7 +66,7 @@ wso2::dep_sync:
 wso2::registry_mounts:
  wso2_config_db:
    path: /_system/config
-   target_path: /_system/config/apim-gw
+   target_path: /_system/config
    read_only: true
    registry_root: /
    enable_cache: true


### PR DESCRIPTION
Having multiple path locations for each node cause issues in multi tenant environment. Making it to a single path would solve those issues