### PR TITLE
Adding unit file support for RHEL 7

### DIFF
--- a/modules/wso2base/manifests/system.pp
+++ b/modules/wso2base/manifests/system.pp
@@ -56,6 +56,16 @@ class wso2base::system (
       mode    => '0755',
       content => template($service_template),
     }
+
+  if ($osfamily == 'RedHat') and ($operatingsystemmajrelease >= 7) {
+    file { "/etc/systemd/system/${service_name}.service":
+      ensure  => present,
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+      content => template(wso2base/wso2unit.erb)
+      }
+    }
   }
 
   if $::vm_type != 'docker' {

--- a/modules/wso2base/templates/wso2unit.erb
+++ b/modules/wso2base/templates/wso2unit.erb
@@ -1,0 +1,16 @@
+[Unit]
+Description=<%= @service_name %> Server
+After=syslog.target network.target
+
+[Service]
+Type=oneshot
+ExecStart=<%= @carbon_home %>/bin/wso2server.sh start
+ExecStop=<%= @carbon_home %>/bin/wso2server.sh stop
+PIDFile=<%= @carbon_home %>/bin/wso2carbon.pid
+User=<%= @wso2_user %>
+RemainAfterExit=yes
+StandardOutput=syslog
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
In RHEL/CentOS 7.0 it switched to systemd, a system and service manager, that replaces SysV and Upstart used in previous releases of Red Hat Enterprise Linux.